### PR TITLE
Implement DB-backed login and registration

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Usuario.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Usuario.java
@@ -1,0 +1,20 @@
+package com.compulandia.sistematickets.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Usuario {
+    @Id
+    private String username;
+    private String password;
+    private String role;
+}

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/UsuarioRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/UsuarioRepository.java
@@ -1,0 +1,11 @@
+package com.compulandia.sistematickets.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.compulandia.sistematickets.entities.Usuario;
+
+@Repository
+public interface UsuarioRepository extends JpaRepository<Usuario, String> {
+    Usuario findByUsername(String username);
+}

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/AuthController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/AuthController.java
@@ -1,0 +1,36 @@
+package com.compulandia.sistematickets.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.compulandia.sistematickets.entities.Usuario;
+import com.compulandia.sistematickets.repository.UsuarioRepository;
+
+@RestController
+@RequestMapping("/api/auth")
+@CrossOrigin("*")
+public class AuthController {
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @PostMapping("/register")
+    public Usuario register(@RequestBody Usuario usuario){
+        return usuarioRepository.save(usuario);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Usuario> login(@RequestBody Usuario loginRequest){
+        Usuario usuario = usuarioRepository.findByUsername(loginRequest.getUsername());
+        if(usuario != null && usuario.getPassword().equals(loginRequest.getPassword())){
+            return ResponseEntity.ok(usuario);
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+}

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -13,11 +13,13 @@ import { AuthGuard } from './guards/auth.guard';
 import { AuthorizationGuard } from './guards/authorization.guard.ts';
 import { TecnicoDetallesComponent } from './tecnico-detalles/tecnico-detalles.component';
 import { NewTicketComponent } from './new-ticket/new-ticket.component';
+import { RegisterComponent } from './register/register.component';
 
 
 const routes: Routes = [
   { path: "", component: LoginComponent },
   { path: "login", component: LoginComponent },
+  { path: "register", component: RegisterComponent },
   {
     path: "admin", component: AdminTemplateComponent,
     canActivate: [AuthGuard], // Assuming AuthGuard is imported and provided in the module

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { NewTicketComponent } from './new-ticket/new-ticket.component';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
+import { RegisterComponent } from './register/register.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -50,6 +51,7 @@ import { MatSelectModule } from '@angular/material/select';
     TecnicoDetallesComponent,
     NewTicketComponent,
     NewTicketComponent,
+    RegisterComponent,
   ],
   imports: [
     BrowserModule,

--- a/sistema-tickets-frontend/src/app/login/login.component.css
+++ b/sistema-tickets-frontend/src/app/login/login.component.css
@@ -90,3 +90,13 @@ mat-form-field {
 .login-button:hover {
   background-color: #2980b9;
 }
+
+.register-link {
+  margin-top: 10px;
+  text-align: center;
+}
+
+.register-link a {
+  margin-left: 4px;
+  color: #3498db;
+}

--- a/sistema-tickets-frontend/src/app/login/login.component.html
+++ b/sistema-tickets-frontend/src/app/login/login.component.html
@@ -25,7 +25,11 @@
         >
       </div>
 
-      <button type="submit" class="login-button">Acceder</button>
+    <button type="submit" class="login-button">Acceder</button>
+    <div class="register-link">
+      ¿No tienes cuenta?
+      <a routerLink="/register">Regístrate</a>
+    </div>
     </form>
   </div>
 </div>

--- a/sistema-tickets-frontend/src/app/login/login.component.ts
+++ b/sistema-tickets-frontend/src/app/login/login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
+import { Usuario } from '../models/usuario.model';
 
 @Component({
   selector: 'app-login',
@@ -21,12 +22,11 @@ export class LoginComponent implements OnInit {
   }
 
   login(): void {
-    let username = this.loginForm.value.username;
-    let password = this.loginForm.value.password;
-    let auth: boolean = this.authService.login(username, password);
-
-    if (auth == true) {
-      this.router.navigateByUrl("/admin");
-    }
+    const username = this.loginForm.value.username;
+    const password = this.loginForm.value.password;
+    this.authService.login(username, password).subscribe({
+      next: () => this.router.navigateByUrl('/admin'),
+      error: () => alert('Credenciales incorrectas')
+    });
   }
 }

--- a/sistema-tickets-frontend/src/app/models/usuario.model.ts
+++ b/sistema-tickets-frontend/src/app/models/usuario.model.ts
@@ -1,0 +1,5 @@
+export interface Usuario {
+  username: string;
+  password: string;
+  role: string;
+}

--- a/sistema-tickets-frontend/src/app/register/register.component.css
+++ b/sistema-tickets-frontend/src/app/register/register.component.css
@@ -1,0 +1,44 @@
+.register-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f5f7fa;
+  padding: 20px;
+}
+
+.register-card {
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  padding: 40px;
+}
+
+.register-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.register-button {
+  background-color: #3498db;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 12px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+.register-button:hover {
+  background-color: #2980b9;
+}

--- a/sistema-tickets-frontend/src/app/register/register.component.html
+++ b/sistema-tickets-frontend/src/app/register/register.component.html
@@ -1,0 +1,16 @@
+<div class="register-container">
+  <div class="register-card">
+    <h2>Registro</h2>
+    <form [formGroup]="registerForm" (ngSubmit)="register()" class="register-form">
+      <div class="form-group">
+        <label for="username">Usuario</label>
+        <input id="username" formControlName="username" type="text" />
+      </div>
+      <div class="form-group">
+        <label for="password">Contraseña</label>
+        <input id="password" formControlName="password" type="password" />
+      </div>
+      <button type="submit" class="register-button">Registrar</button>
+    </form>
+  </div>
+</div>

--- a/sistema-tickets-frontend/src/app/register/register.component.ts
+++ b/sistema-tickets-frontend/src/app/register/register.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AuthService } from '../services/auth.service';
+import { Router } from '@angular/router';
+import { Usuario } from '../models/usuario.model';
+
+@Component({
+  selector: 'app-register',
+  templateUrl: './register.component.html',
+  styleUrls: ['./register.component.css']
+})
+export class RegisterComponent {
+  registerForm: FormGroup;
+
+  constructor(private fb: FormBuilder, private authService: AuthService, private router: Router) {
+    this.registerForm = this.fb.group({
+      username: ['', Validators.required],
+      password: ['', Validators.required],
+      role: ['TECNICO', Validators.required]
+    });
+  }
+
+  register() {
+    const usuario: Usuario = this.registerForm.value;
+    this.authService.register(usuario).subscribe({
+      next: () => this.router.navigateByUrl('/login'),
+      error: () => alert('No se pudo registrar')
+    });
+  }
+}

--- a/sistema-tickets-frontend/src/app/services/auth.service.ts
+++ b/sistema-tickets-frontend/src/app/services/auth.service.ts
@@ -1,33 +1,36 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap, map } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { Usuario } from '../models/usuario.model';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
 
-  public users: any = {
-    admin: { password: 'admin123', roles: ['TECNICO', 'ADMIN'] },
-    user1: { password: 'user123', roles: ['TECNICO'] },
-  }
-
 public username: any;
 public isAuthenticated: boolean = false;
-public roles: string[] = []; 
+public roles: string[] = [];
 
-  constructor(private router: Router) { }
+  constructor(private router: Router, private http: HttpClient) { }
 
+  public login(username: string, password: string): Observable<boolean> {
+    return this.http
+      .post<Usuario>(`${environment.backendHost}/api/auth/login`, { username, password })
+      .pipe(
+        tap((user: Usuario) => {
+          this.username = user.username;
+          this.roles = [user.role];
+          this.isAuthenticated = true;
+        }),
+        map(() => true)
+      );
+  }
 
-  public login(username: string, password: string): boolean {
-    if (this.users[username] && this.users[username]['password'] === password) {
-      this.username= username;
-      this.isAuthenticated = true;
-      this.roles = this.users[username]['roles'];
-      return true;
-    }
-    else {
-      return false;
-    }
+  public register(usuario: Usuario): Observable<Usuario> {
+    return this.http.post<Usuario>(`${environment.backendHost}/api/auth/register`, usuario);
   }
 
   logout(){


### PR DESCRIPTION
## Summary
- add `Usuario` entity and repository
- implement `AuthController` for login and registration endpoints
- create Angular model and service methods for authentication
- modify login component to use backend and add link to new register page
- add registration component and routing

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860cac84ab88323b840c6abd8cbe0c0