### PR TITLE
Fix CORS preflight for login

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/config/CorsConfig.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.compulandia.sistematickets.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOriginPattern("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.setAllowCredentials(true);
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
## Summary
- add a global CORS filter so Angular app can hit the backend

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*
- `npm test` *(fails: missing @rollup package)*

------
https://chatgpt.com/codex/tasks/task_e_6860cff903c88323932197dca002ff09