### PR TITLE
Enhance ticket form

### DIFF
--- a/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.html
+++ b/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.html
@@ -8,10 +8,8 @@
                 <mat-label>Fecha de ticket</mat-label>
                 <mat-hint>MM-DD-YYYY</mat-hint>
                 <input matInput [matDatepicker]="picker" formControlName="date">
-                <mat-datepicker-toggle matIconSuffix
-                    [for]="picker"></mat-datepicker-toggle>
+                <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
                 <mat-datepicker #picker></mat-datepicker>
-
             </mat-form-field>
             <mat-form-field appearance="outline">
                 <mat-label>Cantidad</mat-label>
@@ -20,14 +18,72 @@
             <mat-form-field appearance="outline">
                 <mat-label>Tipo de Servicio</mat-label>
                 <mat-select formControlName="type">
-                    <mat-option *ngFor="let tipo of tiposTickets"
-                        [value]="tipo">{{ tipo }}</mat-option>
+                    <mat-option *ngFor="let tipo of tiposTickets" [value]="tipo">{{ tipo }}</mat-option>
                 </mat-select>
             </mat-form-field>
+            <!-- Campos adicionales para Instalación -->
+            <div *ngIf="ticketFormGroup.get('type')?.value === 'INSTALACION'">
+                <mat-form-field appearance="outline">
+                    <mat-label>Equipo a instalar</mat-label>
+                    <input matInput formControlName="instalacionEquipo" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Modelo</mat-label>
+                    <input matInput formControlName="instalacionModelo" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Dirección de instalación</mat-label>
+                    <input matInput formControlName="instalacionDireccion" />
+                </mat-form-field>
+            </div>
+            <!-- Campos adicionales para Mantenimiento -->
+            <div *ngIf="ticketFormGroup.get('type')?.value === 'MANTENIMIENTO'">
+                <mat-form-field appearance="outline">
+                    <mat-label>Equipo</mat-label>
+                    <input matInput formControlName="mantenimientoEquipo" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Descripción del trabajo</mat-label>
+                    <input matInput formControlName="mantenimientoDescripcion" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Próxima fecha</mat-label>
+                    <input matInput formControlName="mantenimientoProxima" />
+                </mat-form-field>
+            </div>
+            <!-- Campos adicionales para Cotización -->
+            <div *ngIf="ticketFormGroup.get('type')?.value === 'COTIZACION'">
+                <mat-form-field appearance="outline">
+                    <mat-label>Cliente</mat-label>
+                    <input matInput formControlName="cotizacionCliente" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Monto estimado</mat-label>
+                    <input matInput formControlName="cotizacionMonto" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Descripción</mat-label>
+                    <input matInput formControlName="cotizacionDescripcion" />
+                </mat-form-field>
+            </div>
+            <!-- Campos adicionales para Diagnóstico -->
+            <div *ngIf="ticketFormGroup.get('type')?.value === 'DIAGNOSTICO'">
+                <mat-form-field appearance="outline">
+                    <mat-label>Equipo</mat-label>
+                    <input matInput formControlName="diagnosticoEquipo" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Problema reportado</mat-label>
+                    <input matInput formControlName="diagnosticoProblema" />
+                </mat-form-field>
+                <mat-form-field appearance="outline">
+                    <mat-label>Observaciones</mat-label>
+                    <input matInput formControlName="diagnosticoObservaciones" />
+                </mat-form-field>
+            </div>
             <mat-form-field appearance="outline">
                 <mat-label>Código Técnico</mat-label>
-                <input matInput formControlName="codigoTecnico"
-                    [value]="codigoTecnico" readonly />
+                <input matInput formControlName="codigoTecnico" [value]="codigoTecnico" readonly />
             </mat-form-field>
             <mat-form-field appearance="outline">
                 <mat-label>Archivo</mat-label>
@@ -35,14 +91,11 @@
                 <button type="button" mat-icon-button matPrefix (click)="f_input.click()">
                     <mat-icon>attach_file</mat-icon>
                 </button>
-                <input type="file" hidden #f_input (change)="selectFile($event)"
-                    accept="application/pdf" />
+                <input type="file" hidden #f_input (change)="selectFile($event)" accept="application/pdf" />
             </mat-form-field>
             <mat-card-actions>
-                <button mat-raised-button color="primary"
-                    (click)="guardarTicket()">Guardar Ticket</button>
+                <button mat-raised-button color="primary" (click)="guardarTicket()">Guardar Ticket</button>
             </mat-card-actions>
-
         </mat-card-content>
     </mat-card>
 </div>

--- a/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.ts
+++ b/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.ts
@@ -16,7 +16,8 @@ export class NewTicketComponent implements OnInit{
   codigoTecnico!: string;
   tiposTickets: string[] = [];
   pdfFileUrl!: string;
-  constructor(private fb:FormBuilder, private activatedRoute:ActivatedRoute, private tecnicoService: TecnicosService) { 
+  // Fields specific to each type of servicio will be handled through the reactive form
+  constructor(private fb:FormBuilder, private activatedRoute:ActivatedRoute, private tecnicoService: TecnicosService) {
     // Initialize the form group and other properties here if needed
 
 
@@ -35,6 +36,22 @@ export class NewTicketComponent implements OnInit{
     codigoTecnico: this.fb.control(this.codigoTecnico),
     fileSource: this.fb.control(''),
     fileName: this.fb.control(''),
+    // Campos para Instalación
+    instalacionEquipo: this.fb.control(''),
+    instalacionModelo: this.fb.control(''),
+    instalacionDireccion: this.fb.control(''),
+    // Campos para Mantenimiento
+    mantenimientoEquipo: this.fb.control(''),
+    mantenimientoDescripcion: this.fb.control(''),
+    mantenimientoProxima: this.fb.control(''),
+    // Campos para Cotización
+    cotizacionCliente: this.fb.control(''),
+    cotizacionMonto: this.fb.control(''),
+    cotizacionDescripcion: this.fb.control(''),
+    // Campos para Diagnóstico
+    diagnosticoEquipo: this.fb.control(''),
+    diagnosticoProblema: this.fb.control(''),
+    diagnosticoObservaciones: this.fb.control(''),
   });
 }
 
@@ -61,6 +78,19 @@ guardarTicket() {
   formData.set('type', this.ticketFormGroup.value.type);
   formData.set('codigoTecnico', this.ticketFormGroup.value.codigoTecnico);
   formData.append('file', this.ticketFormGroup.value.fileSource);
+  // Adjuntar información adicional según el tipo de servicio
+  formData.set('instalacionEquipo', this.ticketFormGroup.value.instalacionEquipo);
+  formData.set('instalacionModelo', this.ticketFormGroup.value.instalacionModelo);
+  formData.set('instalacionDireccion', this.ticketFormGroup.value.instalacionDireccion);
+  formData.set('mantenimientoEquipo', this.ticketFormGroup.value.mantenimientoEquipo);
+  formData.set('mantenimientoDescripcion', this.ticketFormGroup.value.mantenimientoDescripcion);
+  formData.set('mantenimientoProxima', this.ticketFormGroup.value.mantenimientoProxima);
+  formData.set('cotizacionCliente', this.ticketFormGroup.value.cotizacionCliente);
+  formData.set('cotizacionMonto', this.ticketFormGroup.value.cotizacionMonto);
+  formData.set('cotizacionDescripcion', this.ticketFormGroup.value.cotizacionDescripcion);
+  formData.set('diagnosticoEquipo', this.ticketFormGroup.value.diagnosticoEquipo);
+  formData.set('diagnosticoProblema', this.ticketFormGroup.value.diagnosticoProblema);
+  formData.set('diagnosticoObservaciones', this.ticketFormGroup.value.diagnosticoObservaciones);
 
   
     console.log(formData);


### PR DESCRIPTION
## Summary
- extend new ticket form with fields for each service type
- include extra fields in form submission data

## Testing
- `npm test --silent` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6860d463a2548323ab902365ae1502ef