### PR TITLE
Add technician dashboard

### DIFF
--- a/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
+++ b/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
@@ -31,8 +31,14 @@
     <mat-list>
         <mat-list-item>
             <button mat-button routerLink="/admin/dashboard">
-                <mat-icon>Dasboard</mat-icon>
+                <mat-icon>dashboard</mat-icon>
                 Dashboard
+            </button>
+        </mat-list-item>
+        <mat-list-item>
+            <button mat-button routerLink="/admin/dashboard-tecnico">
+                <mat-icon>dashboard</mat-icon>
+                Dashboard Tecnico
             </button>
         </mat-list-item>
         <mat-list-item>

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -16,6 +16,7 @@ import { NewTicketComponent } from './new-ticket/new-ticket.component';
 import { RegisterComponent } from './register/register.component';
 
 
+import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
 const routes: Routes = [
   { path: "", component: LoginComponent },
   { path: "login", component: LoginComponent },
@@ -34,6 +35,7 @@ const routes: Routes = [
         canActivate: [AuthorizationGuard], data: { roles: ['ADMIN'] }
        },
       { path: "dashboard", component: DashboardComponent },
+      { path: "dashboard-tecnico", component: TecnicoDashboardComponent },
       { path: "tecnicos", component: TecnicosComponent },
       { path: "tickets", component: TicketsComponent },
       { path: "tecnico-detalles/:codigo",  component: TecnicoDetallesComponent },

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { RegisterComponent } from './register/register.component';
+import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -50,8 +51,8 @@ import { RegisterComponent } from './register/register.component';
     DashboardComponent,
     TecnicoDetallesComponent,
     NewTicketComponent,
-    NewTicketComponent,
     RegisterComponent,
+    TecnicoDashboardComponent,
   ],
   imports: [
     BrowserModule,

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
@@ -1,0 +1,40 @@
+.dashboard-container {
+  padding: 16px;
+}
+
+.card-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card {
+  width: 180px;
+  cursor: pointer;
+  color: #fff;
+}
+
+.card.today {
+  background-color: #1976d2;
+}
+
+.card.pending {
+  background-color: #f57c00;
+}
+
+.card.completed {
+  background-color: #388e3c;
+}
+
+.card.historic {
+  background-color: #455a64;
+}
+
+.card.metrics {
+  background-color: #0288d1;
+}
+
+.card.scores {
+  background-color: #7b1fa2;
+}

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
@@ -1,0 +1,168 @@
+<div class="dashboard-container">
+  <div class="card-container">
+    <mat-card class="card today" (click)="setCategory('today')">
+      <mat-card-title>Tickets del día</mat-card-title>
+      <mat-card-content>{{ todayTickets.length }}</mat-card-content>
+    </mat-card>
+    <mat-card class="card pending" (click)="setCategory('pending')">
+      <mat-card-title>Tickets pendientes</mat-card-title>
+      <mat-card-content>{{ pendingTickets.length }}</mat-card-content>
+    </mat-card>
+    <mat-card class="card completed" (click)="setCategory('completed')">
+      <mat-card-title>Tickets completados</mat-card-title>
+      <mat-card-content>{{ completedTickets.length }}</mat-card-content>
+    </mat-card>
+    <mat-card class="card historic" (click)="setCategory('historical')">
+      <mat-card-title>Históricos</mat-card-title>
+      <mat-card-content>{{ tickets.length }}</mat-card-content>
+    </mat-card>
+    <mat-card class="card metrics" (click)="setCategory('metrics')">
+      <mat-card-title>Métricas</mat-card-title>
+      <mat-card-content>Total: {{ tickets.length }}</mat-card-content>
+    </mat-card>
+    <mat-card class="card scores" (click)="setCategory('scores')">
+      <mat-card-title>Puntuaciones</mat-card-title>
+      <mat-card-content>--</mat-card-content>
+    </mat-card>
+  </div>
+
+  <div *ngIf="activeCategory === 'today'">
+    <h3>Tickets del día</h3>
+    <table mat-table [dataSource]="todayDataSource" class="mat-elevation-z1">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let element">{{element.id}}</td>
+      </ng-container>
+      <ng-container matColumnDef="fecha">
+        <th mat-header-cell *matHeaderCellDef>FECHA</th>
+        <td mat-cell *matCellDef="let element">{{element.fecha}}</td>
+      </ng-container>
+      <ng-container matColumnDef="cantidad">
+        <th mat-header-cell *matHeaderCellDef>CANTIDAD</th>
+        <td mat-cell *matCellDef="let element">{{element.cantidad}}</td>
+      </ng-container>
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef>TIPO</th>
+        <td mat-cell *matCellDef="let element">{{element.type}}</td>
+      </ng-container>
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>STATUS</th>
+        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+      </ng-container>
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef>TECNICO</th>
+        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+
+  <div *ngIf="activeCategory === 'pending'">
+    <h3>Tickets pendientes</h3>
+    <table mat-table [dataSource]="pendingDataSource" class="mat-elevation-z1">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let element">{{element.id}}</td>
+      </ng-container>
+      <ng-container matColumnDef="fecha">
+        <th mat-header-cell *matHeaderCellDef>FECHA</th>
+        <td mat-cell *matCellDef="let element">{{element.fecha}}</td>
+      </ng-container>
+      <ng-container matColumnDef="cantidad">
+        <th mat-header-cell *matHeaderCellDef>CANTIDAD</th>
+        <td mat-cell *matCellDef="let element">{{element.cantidad}}</td>
+      </ng-container>
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef>TIPO</th>
+        <td mat-cell *matCellDef="let element">{{element.type}}</td>
+      </ng-container>
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>STATUS</th>
+        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+      </ng-container>
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef>TECNICO</th>
+        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+
+  <div *ngIf="activeCategory === 'completed'">
+    <h3>Tickets completados</h3>
+    <table mat-table [dataSource]="completedDataSource" class="mat-elevation-z1">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let element">{{element.id}}</td>
+      </ng-container>
+      <ng-container matColumnDef="fecha">
+        <th mat-header-cell *matHeaderCellDef>FECHA</th>
+        <td mat-cell *matCellDef="let element">{{element.fecha}}</td>
+      </ng-container>
+      <ng-container matColumnDef="cantidad">
+        <th mat-header-cell *matHeaderCellDef>CANTIDAD</th>
+        <td mat-cell *matCellDef="let element">{{element.cantidad}}</td>
+      </ng-container>
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef>TIPO</th>
+        <td mat-cell *matCellDef="let element">{{element.type}}</td>
+      </ng-container>
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>STATUS</th>
+        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+      </ng-container>
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef>TECNICO</th>
+        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+
+  <div *ngIf="activeCategory === 'historical'">
+    <h3>Históricos</h3>
+    <table mat-table [dataSource]="allDataSource" class="mat-elevation-z1">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>ID</th>
+        <td mat-cell *matCellDef="let element">{{element.id}}</td>
+      </ng-container>
+      <ng-container matColumnDef="fecha">
+        <th mat-header-cell *matHeaderCellDef>FECHA</th>
+        <td mat-cell *matCellDef="let element">{{element.fecha}}</td>
+      </ng-container>
+      <ng-container matColumnDef="cantidad">
+        <th mat-header-cell *matHeaderCellDef>CANTIDAD</th>
+        <td mat-cell *matCellDef="let element">{{element.cantidad}}</td>
+      </ng-container>
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef>TIPO</th>
+        <td mat-cell *matCellDef="let element">{{element.type}}</td>
+      </ng-container>
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>STATUS</th>
+        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+      </ng-container>
+      <ng-container matColumnDef="nombre">
+        <th mat-header-cell *matHeaderCellDef>TECNICO</th>
+        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+
+  <div *ngIf="activeCategory === 'metrics'">
+    <h3>Métricas</h3>
+    <p>Total de tickets: {{ tickets.length }}</p>
+    <p>Pendientes: {{ pendingTickets.length }}</p>
+    <p>Completados: {{ completedTickets.length }}</p>
+  </div>
+
+  <div *ngIf="activeCategory === 'scores'">
+    <h3>Puntuaciones</h3>
+    <p>En construcción...</p>
+  </div>
+</div>

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { MatTableDataSource } from '@angular/material/table';
+import { Ticket } from '../models/tecnicos.model';
+import { TecnicosService } from '../services/tecnicos.service';
+
+@Component({
+  selector: 'app-tecnico-dashboard',
+  templateUrl: './tecnico-dashboard.component.html',
+  styleUrls: ['./tecnico-dashboard.component.css']
+})
+export class TecnicoDashboardComponent implements OnInit {
+  tickets: Ticket[] = [];
+  todayTickets: Ticket[] = [];
+  pendingTickets: Ticket[] = [];
+  completedTickets: Ticket[] = [];
+
+  todayDataSource = new MatTableDataSource<Ticket>();
+  pendingDataSource = new MatTableDataSource<Ticket>();
+  completedDataSource = new MatTableDataSource<Ticket>();
+  allDataSource = new MatTableDataSource<Ticket>();
+
+  displayedColumns: string[] = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre'];
+
+  activeCategory = '';
+
+  constructor(private tecnicosService: TecnicosService) {}
+
+  ngOnInit(): void {
+    this.tecnicosService.getAllTickets().subscribe({
+      next: (data) => {
+        this.tickets = data;
+        this.filterTickets();
+      },
+      error: (err) => {
+        console.error('Error al cargar los tickets', err);
+      }
+    });
+  }
+
+  filterTickets() {
+    const todayStr = new Date().toISOString().split('T')[0];
+    this.todayTickets = this.tickets.filter(t => new Date(t.fecha).toISOString().split('T')[0] === todayStr);
+    this.pendingTickets = this.tickets.filter(t => t.status === 'PENDIENTE' || t.status === 'EN_PROCESO');
+    this.completedTickets = this.tickets.filter(t => t.status === 'FINALIZADO');
+
+    this.todayDataSource.data = this.todayTickets;
+    this.pendingDataSource.data = this.pendingTickets;
+    this.completedDataSource.data = this.completedTickets;
+    this.allDataSource.data = this.tickets;
+  }
+
+  setCategory(cat: string) {
+    this.activeCategory = this.activeCategory === cat ? '' : cat;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new technician dashboard component showing today's tickets, pending, completed, historical and metrics
- link technician dashboard route and navigation item

## Testing
- `npm run build` *(fails: budget errors)*
- `npm test` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6860da4c67ec8323bda1d30351321d79