### PR TITLE
Store extra ticket info

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
@@ -35,6 +35,23 @@ public class Ticket {
     private TicketStatus status;
 
     private String file;
+
+    // Campos adicionales para cada tipo de servicio
+    private String instalacionEquipo;
+    private String instalacionModelo;
+    private String instalacionDireccion;
+
+    private String mantenimientoEquipo;
+    private String mantenimientoDescripcion;
+    private String mantenimientoProxima;
+
+    private String cotizacionCliente;
+    private String cotizacionMonto;
+    private String cotizacionDescripcion;
+
+    private String diagnosticoEquipo;
+    private String diagnosticoProblema;
+    private String diagnosticoObservaciones;
     
     @ManyToOne
     private Tecnico tecnico;

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -31,7 +31,19 @@ public class TicketService {
     private TecnicoRepository tecnicoRepository;
 
     public Ticket saveTicket(MultipartFile file, double cantidad, TypeTicket typeTicket, LocalDate date,
-            String codigoTecnico) throws IOException {
+            String codigoTecnico,
+            String instalacionEquipo,
+            String instalacionModelo,
+            String instalacionDireccion,
+            String mantenimientoEquipo,
+            String mantenimientoDescripcion,
+            String mantenimientoProxima,
+            String cotizacionCliente,
+            String cotizacionMonto,
+            String cotizacionDescripcion,
+            String diagnosticoEquipo,
+            String diagnosticoProblema,
+            String diagnosticoObservaciones) throws IOException {
 
         Path filePath = null;
         if (file != null && !file.isEmpty()) {
@@ -68,6 +80,18 @@ public class TicketService {
                 .tecnico(tecnico)
                 .cantidad(cantidad)
                 .file(filePath != null ? filePath.toUri().toString() : null)
+                .instalacionEquipo(instalacionEquipo)
+                .instalacionModelo(instalacionModelo)
+                .instalacionDireccion(instalacionDireccion)
+                .mantenimientoEquipo(mantenimientoEquipo)
+                .mantenimientoDescripcion(mantenimientoDescripcion)
+                .mantenimientoProxima(mantenimientoProxima)
+                .cotizacionCliente(cotizacionCliente)
+                .cotizacionMonto(cotizacionMonto)
+                .cotizacionDescripcion(cotizacionDescripcion)
+                .diagnosticoEquipo(diagnosticoEquipo)
+                .diagnosticoProblema(diagnosticoProblema)
+                .diagnosticoObservaciones(diagnosticoObservaciones)
                 .build();
 
         return ticketRepository.save(ticket);

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -84,9 +84,39 @@ public Ticket guardarTicket(
     @RequestParam("cantidad") double cantidad,
     @RequestParam("type") TypeTicket type,
     @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-    @RequestParam("codigoTecnico") String codigoTecnico
+    @RequestParam("codigoTecnico") String codigoTecnico,
+    @RequestParam(value="instalacionEquipo", required = false) String instalacionEquipo,
+    @RequestParam(value="instalacionModelo", required = false) String instalacionModelo,
+    @RequestParam(value="instalacionDireccion", required = false) String instalacionDireccion,
+    @RequestParam(value="mantenimientoEquipo", required = false) String mantenimientoEquipo,
+    @RequestParam(value="mantenimientoDescripcion", required = false) String mantenimientoDescripcion,
+    @RequestParam(value="mantenimientoProxima", required = false) String mantenimientoProxima,
+    @RequestParam(value="cotizacionCliente", required = false) String cotizacionCliente,
+    @RequestParam(value="cotizacionMonto", required = false) String cotizacionMonto,
+    @RequestParam(value="cotizacionDescripcion", required = false) String cotizacionDescripcion,
+    @RequestParam(value="diagnosticoEquipo", required = false) String diagnosticoEquipo,
+    @RequestParam(value="diagnosticoProblema", required = false) String diagnosticoProblema,
+    @RequestParam(value="diagnosticoObservaciones", required = false) String diagnosticoObservaciones
 ) throws IOException {
-    return ticketService.saveTicket(file, cantidad, type, date, codigoTecnico);
+    return ticketService.saveTicket(
+        file,
+        cantidad,
+        type,
+        date,
+        codigoTecnico,
+        instalacionEquipo,
+        instalacionModelo,
+        instalacionDireccion,
+        mantenimientoEquipo,
+        mantenimientoDescripcion,
+        mantenimientoProxima,
+        cotizacionCliente,
+        cotizacionMonto,
+        cotizacionDescripcion,
+        diagnosticoEquipo,
+        diagnosticoProblema,
+        diagnosticoObservaciones
+    );
 }
 
     @GetMapping(value = "/ticketfile/{ticketId}", produces = MediaType.APPLICATION_PDF_VALUE)

--- a/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
+++ b/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
@@ -15,6 +15,18 @@ export interface Ticket {
     status: string;
     file: string;
     tecnico: Tecnico;
+    instalacionEquipo?: string;
+    instalacionModelo?: string;
+    instalacionDireccion?: string;
+    mantenimientoEquipo?: string;
+    mantenimientoDescripcion?: string;
+    mantenimientoProxima?: string;
+    cotizacionCliente?: string;
+    cotizacionMonto?: string;
+    cotizacionDescripcion?: string;
+    diagnosticoEquipo?: string;
+    diagnosticoProblema?: string;
+    diagnosticoObservaciones?: string;
 }
 
 export enum TicketType {

--- a/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.html
+++ b/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.html
@@ -48,11 +48,35 @@
                     <td mat-cell
                         *matCellDef="let element">{{element.tecnico.nombre}}</td>
                 </ng-container>
-                <ng-container matColumnDef="acciones">
-                    <th mat-header-cell *matHeaderCellDef >
-                        ACCIONES </th>
-                    <td mat-cell
-                        *matCellDef="let element">{{element.acciones}}</td>
+
+                <ng-container matColumnDef="info1">
+                    <th mat-header-cell *matHeaderCellDef>INFO 1</th>
+                    <td mat-cell *matCellDef="let element">
+                        {{ element.type === 'INSTALACION' ? element.instalacionEquipo :
+                           element.type === 'MANTENIMIENTO' ? element.mantenimientoEquipo :
+                           element.type === 'COTIZACION' ? element.cotizacionCliente :
+                           element.type === 'DIAGNOSTICO' ? element.diagnosticoEquipo : '' }}
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="info2">
+                    <th mat-header-cell *matHeaderCellDef>INFO 2</th>
+                    <td mat-cell *matCellDef="let element">
+                        {{ element.type === 'INSTALACION' ? element.instalacionModelo :
+                           element.type === 'MANTENIMIENTO' ? element.mantenimientoDescripcion :
+                           element.type === 'COTIZACION' ? element.cotizacionMonto :
+                           element.type === 'DIAGNOSTICO' ? element.diagnosticoProblema : '' }}
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="info3">
+                    <th mat-header-cell *matHeaderCellDef>INFO 3</th>
+                    <td mat-cell *matCellDef="let element">
+                        {{ element.type === 'INSTALACION' ? element.instalacionDireccion :
+                           element.type === 'MANTENIMIENTO' ? element.mantenimientoProxima :
+                           element.type === 'COTIZACION' ? element.cotizacionDescripcion :
+                           element.type === 'DIAGNOSTICO' ? element.diagnosticoObservaciones : '' }}
+                    </td>
                 </ng-container>
 
                 <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.ts
@@ -16,7 +16,7 @@ export class TecnicoDetallesComponent {
   ticketsTecnico!: Array<Ticket>;
   ticketsDataSource!: MatTableDataSource<Ticket>;
 
-  public displayedColumns: string[] = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre'];
+  public displayedColumns: string[] = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre', 'info1', 'info2', 'info3'];
 
   constructor(private activatedRoute: ActivatedRoute, private tecnicosService: TecnicosService, private router: Router) { }
 

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.html
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.html
@@ -45,11 +45,35 @@
                     <td mat-cell
                         *matCellDef="let element">{{element.tecnico.nombre}}</td>
                 </ng-container>
-                <ng-container matColumnDef="acciones">
-                    <th mat-header-cell *matHeaderCellDef mat-sort-header>
-                        ACCIONES </th>
-                    <td mat-cell
-                        *matCellDef="let element">{{element.acciones}}</td>
+
+                <ng-container matColumnDef="info1">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header>INFO 1</th>
+                    <td mat-cell *matCellDef="let element">
+                        {{ element.type === 'INSTALACION' ? element.instalacionEquipo :
+                           element.type === 'MANTENIMIENTO' ? element.mantenimientoEquipo :
+                           element.type === 'COTIZACION' ? element.cotizacionCliente :
+                           element.type === 'DIAGNOSTICO' ? element.diagnosticoEquipo : '' }}
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="info2">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header>INFO 2</th>
+                    <td mat-cell *matCellDef="let element">
+                        {{ element.type === 'INSTALACION' ? element.instalacionModelo :
+                           element.type === 'MANTENIMIENTO' ? element.mantenimientoDescripcion :
+                           element.type === 'COTIZACION' ? element.cotizacionMonto :
+                           element.type === 'DIAGNOSTICO' ? element.diagnosticoProblema : '' }}
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="info3">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header>INFO 3</th>
+                    <td mat-cell *matCellDef="let element">
+                        {{ element.type === 'INSTALACION' ? element.instalacionDireccion :
+                           element.type === 'MANTENIMIENTO' ? element.mantenimientoProxima :
+                           element.type === 'COTIZACION' ? element.cotizacionDescripcion :
+                           element.type === 'DIAGNOSTICO' ? element.diagnosticoObservaciones : '' }}
+                    </td>
                 </ng-container>
 
                 <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.ts
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.ts
@@ -13,7 +13,7 @@ import { TecnicosService } from '../services/tecnicos.service';
 export class TicketsComponent implements OnInit {
 public tickets: any;
   public dataSource: any;
-  public displayedColumns = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre', 'acciones'];
+  public displayedColumns = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre', 'info1', 'info2', 'info3'];
 
   /*@ViewChild es un decorador que permite acceder a un componente hijo del DOM */
   @ViewChild(MatPaginator) paginator!: MatPaginator;


### PR DESCRIPTION
## Summary
- persist service-specific fields for each ticket
- expose new fields in TicketController
- display details columns in ticket lists
- extend ticket interfaces with extra fields

## Testing
- `npm test --silent` *(fails: ng permission denied)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860dbb84e188323bb0c41a67105049d