### PR TITLE
Personalize dashboard for technicians

### DIFF
--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -23,6 +23,10 @@ export class TecnicosService {
     return this.http.get<Array<Ticket>>(`${environment.backendHost}/tecnicos/${codigo}/tickets`);
   }
 
+  public getTecnicoPorCodigo(codigo: string): Observable<Tecnico> {
+    return this.http.get<Tecnico>(`${environment.backendHost}/tecnicos/${codigo}`);
+  }
+
   public guardarTicket(formData: any): Observable<Ticket> {
     return this.http.post<Ticket>(`${environment.backendHost}/tickets`, formData);
   }

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { Ticket } from '../models/tecnicos.model';
 import { TecnicosService } from '../services/tecnicos.service';
+import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-tecnico-dashboard',
@@ -13,6 +14,7 @@ export class TecnicoDashboardComponent implements OnInit {
   todayTickets: Ticket[] = [];
   pendingTickets: Ticket[] = [];
   completedTickets: Ticket[] = [];
+  tecnicoCodigo: string | undefined;
 
   todayDataSource = new MatTableDataSource<Ticket>();
   pendingDataSource = new MatTableDataSource<Ticket>();
@@ -23,10 +25,14 @@ export class TecnicoDashboardComponent implements OnInit {
 
   activeCategory = '';
 
-  constructor(private tecnicosService: TecnicosService) {}
+  constructor(private tecnicosService: TecnicosService, private authService: AuthService) {}
 
   ngOnInit(): void {
-    this.tecnicosService.getAllTickets().subscribe({
+    this.tecnicoCodigo = this.authService.username;
+    if (!this.tecnicoCodigo) {
+      return;
+    }
+    this.tecnicosService.getTicketsDeTecnico(this.tecnicoCodigo).subscribe({
       next: (data) => {
         this.tickets = data;
         this.filterTickets();


### PR DESCRIPTION
## Summary
- add method to fetch tecnico by code
- filter tickets by logged in technician in `TecnicoDashboard`

## Testing
- `npx ng test --watch=false` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860df7499f08323ae432b77596b7f21