### PR TITLE
Add technician registration form

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
@@ -1,5 +1,23 @@
 package com.compulandia.sistematickets.web;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.compulandia.sistematickets.entities.Tecnico;
+import com.compulandia.sistematickets.repository.TecnicoRepository;
+
+@RestController
+@CrossOrigin("*")
 public class TecnicoController {
-    
+
+    @Autowired
+    private TecnicoRepository tecnicoRepository;
+
+    @PostMapping("/tecnicos")
+    public Tecnico saveTecnico(@RequestBody Tecnico tecnico) {
+        return tecnicoRepository.save(tecnico);
+    }
 }

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.css
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.css
@@ -1,0 +1,9 @@
+:host {
+  display: block;
+  padding: 20px;
+}
+
+.tecnico-form {
+  max-width: 600px;
+  margin: 0 auto;
+}

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
@@ -1,1 +1,28 @@
-<p>load-tecnicos works!</p>
+<div class="container">
+  <mat-card [formGroup]="tecnicoForm" class="tecnico-form">
+    <mat-card-header>
+      <mat-card-title>Registrar Técnico</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <mat-form-field appearance="outline">
+        <mat-label>Nombre</mat-label>
+        <input matInput formControlName="nombre" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Apellido</mat-label>
+        <input matInput formControlName="apellido" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Código</mat-label>
+        <input matInput formControlName="codigo" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Especialidad</mat-label>
+        <input matInput formControlName="especialidad" />
+      </mat-form-field>
+      <mat-card-actions>
+        <button mat-raised-button color="primary" (click)="guardarTecnico()">Guardar Técnico</button>
+      </mat-card-actions>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -1,10 +1,39 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { TecnicosService } from '../services/tecnicos.service';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-load-tecnicos',
   templateUrl: './load-tecnicos.component.html',
   styleUrls: ['./load-tecnicos.component.css']
 })
-export class LoadTecnicosComponent {
+export class LoadTecnicosComponent implements OnInit {
+  tecnicoForm!: FormGroup;
 
+  constructor(private fb: FormBuilder, private tecnicosService: TecnicosService) {}
+
+  ngOnInit(): void {
+    this.tecnicoForm = this.fb.group({
+      nombre: ['', Validators.required],
+      apellido: ['', Validators.required],
+      codigo: ['', Validators.required],
+      especialidad: ['', Validators.required]
+    });
+  }
+
+  guardarTecnico() {
+    if (this.tecnicoForm.invalid) {
+      return;
+    }
+    this.tecnicosService.crearTecnico(this.tecnicoForm.value).subscribe({
+      next: () => {
+        Swal.fire('Técnico guardado', 'El técnico se ha registrado correctamente', 'success');
+        this.tecnicoForm.reset();
+      },
+      error: () => {
+        Swal.fire('Error', 'No se pudo guardar el técnico', 'error');
+      }
+    });
+  }
 }

--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -27,6 +27,10 @@ export class TecnicosService {
     return this.http.get<Tecnico>(`${environment.backendHost}/tecnicos/${codigo}`);
   }
 
+  public crearTecnico(tecnico: Tecnico): Observable<Tecnico> {
+    return this.http.post<Tecnico>(`${environment.backendHost}/tecnicos`, tecnico);
+  }
+
   public guardarTicket(formData: any): Observable<Ticket> {
     return this.http.post<Ticket>(`${environment.backendHost}/tickets`, formData);
   }


### PR DESCRIPTION
## Summary
- implement backend controller to register technicians
- add service method to create technicians
- flesh out load-tecnicos component with reactive form

## Testing
- `npm test` *(fails: ng permission denied)*
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e2d100e48323a32bcb4b774143a0