### PR TITLE
Implement automatic technician code

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.compulandia.sistematickets.entities.Tecnico;
@@ -19,5 +20,11 @@ public class TecnicoController {
     @PostMapping("/tecnicos")
     public Tecnico saveTecnico(@RequestBody Tecnico tecnico) {
         return tecnicoRepository.save(tecnico);
+    }
+
+    @GetMapping("/tecnicos/proximoCodigo")
+    public String obtenerProximoCodigo() {
+        long count = tecnicoRepository.count() + 1;
+        return String.format("TE-%03d", count);
     }
 }

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
@@ -14,7 +14,7 @@
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Código</mat-label>
-        <input matInput formControlName="codigo" />
+        <input matInput formControlName="codigo" readonly />
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Especialidad</mat-label>

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -20,6 +20,10 @@ export class LoadTecnicosComponent implements OnInit {
       codigo: ['', Validators.required],
       especialidad: ['', Validators.required]
     });
+
+    this.tecnicosService.obtenerProximoCodigo().subscribe(code => {
+      this.tecnicoForm.patchValue({ codigo: code });
+    });
   }
 
   guardarTecnico() {

--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -31,6 +31,10 @@ export class TecnicosService {
     return this.http.post<Tecnico>(`${environment.backendHost}/tecnicos`, tecnico);
   }
 
+  public obtenerProximoCodigo(): Observable<string> {
+    return this.http.get(`${environment.backendHost}/tecnicos/proximoCodigo`, { responseType: 'text' });
+  }
+
   public guardarTicket(formData: any): Observable<Ticket> {
     return this.http.post<Ticket>(`${environment.backendHost}/tickets`, formData);
   }


### PR DESCRIPTION
## Summary
- add endpoint for next technician code generation
- fetch the next code on technician form load
- make technician code field read-only

## Testing
- `./mvnw -q -DskipTests install` *(fails: Could not resolve dependencies)*
- `npm test -- --watch=false` *(fails: missing optional dependency @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6860e60263748323aa334e3f8edad227