### PR TITLE
Add servicios management

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Servicio.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Servicio.java
@@ -1,0 +1,23 @@
+package com.compulandia.sistematickets.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Servicio {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nombre;
+}

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/ServicioRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/ServicioRepository.java
@@ -1,0 +1,10 @@
+package com.compulandia.sistematickets.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.compulandia.sistematickets.entities.Servicio;
+
+@Repository
+public interface ServicioRepository extends JpaRepository<Servicio, Long> {
+}

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/ServicioController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/ServicioController.java
@@ -1,0 +1,31 @@
+package com.compulandia.sistematickets.web;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.compulandia.sistematickets.entities.Servicio;
+import com.compulandia.sistematickets.repository.ServicioRepository;
+
+@RestController
+@CrossOrigin("*")
+public class ServicioController {
+
+    @Autowired
+    private ServicioRepository servicioRepository;
+
+    @GetMapping("/servicios")
+    public List<Servicio> getServicios(){
+        return servicioRepository.findAll();
+    }
+
+    @PostMapping("/servicios")
+    public Servicio createServicio(@RequestBody Servicio servicio){
+        return servicioRepository.save(servicio);
+    }
+}

--- a/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
+++ b/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
@@ -15,6 +15,9 @@
         <button mat-menu-item routerLink="/admin/loadTecnicos">
             Cargar Tecnicos
         </button>
+        <button mat-menu-item routerLink="/admin/loadServicios">
+            Cargar Servicios
+        </button>
         <button mat-menu-item routerLink="/admin/loadTickets">
             Cargar Tickets
         </button>
@@ -45,6 +48,12 @@
              <button mat-button routerLink="/admin/tecnicos">
                 <mat-icon>Dasboard</mat-icon>
                 Tecnicos
+             </button>
+        </mat-list-item>
+        <mat-list-item>
+             <button mat-button routerLink="/admin/loadServicios">
+                <mat-icon>Dasboard</mat-icon>
+                Servicios
              </button>
         </mat-list-item>
         <mat-list-item>

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -17,6 +17,7 @@ import { RegisterComponent } from './register/register.component';
 
 
 import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
+import { LoadServiciosComponent } from './load-servicios/load-servicios.component';
 const routes: Routes = [
   { path: "", component: LoginComponent },
   { path: "login", component: LoginComponent },
@@ -28,6 +29,9 @@ const routes: Routes = [
       { path: "home", component: HomeComponent },
       { path: "profile", component: ProfileComponent },
       { path: "loadTecnicos", component: LoadTecnicosComponent,
+        canActivate: [AuthorizationGuard], data: { roles: ['ADMIN']},
+       },
+      { path: "loadServicios", component: LoadServiciosComponent,
         canActivate: [AuthorizationGuard], data: { roles: ['ADMIN']},
        },
 

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { RegisterComponent } from './register/register.component';
 import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
+import { LoadServiciosComponent } from './load-servicios/load-servicios.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -53,6 +54,7 @@ import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard
     NewTicketComponent,
     RegisterComponent,
     TecnicoDashboardComponent,
+    LoadServiciosComponent,
   ],
   imports: [
     BrowserModule,

--- a/sistema-tickets-frontend/src/app/load-servicios/load-servicios.component.html
+++ b/sistema-tickets-frontend/src/app/load-servicios/load-servicios.component.html
@@ -1,0 +1,16 @@
+<div class="container">
+  <mat-card [formGroup]="servicioForm" class="servicio-form">
+    <mat-card-header>
+      <mat-card-title>Registrar Servicio</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <mat-form-field appearance="outline">
+        <mat-label>Nombre</mat-label>
+        <input matInput formControlName="nombre" />
+      </mat-form-field>
+      <mat-card-actions>
+        <button mat-raised-button color="primary" (click)="guardarServicio()">Guardar Servicio</button>
+      </mat-card-actions>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/sistema-tickets-frontend/src/app/load-servicios/load-servicios.component.ts
+++ b/sistema-tickets-frontend/src/app/load-servicios/load-servicios.component.ts
@@ -1,0 +1,36 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ServiciosService } from '../services/servicios.service';
+import Swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-load-servicios',
+  templateUrl: './load-servicios.component.html',
+  styleUrls: ['./load-servicios.component.css']
+})
+export class LoadServiciosComponent implements OnInit {
+  servicioForm!: FormGroup;
+
+  constructor(private fb: FormBuilder, private serviciosService: ServiciosService) {}
+
+  ngOnInit(): void {
+    this.servicioForm = this.fb.group({
+      nombre: ['', Validators.required]
+    });
+  }
+
+  guardarServicio() {
+    if (this.servicioForm.invalid) {
+      return;
+    }
+    this.serviciosService.crearServicio(this.servicioForm.value).subscribe({
+      next: () => {
+        Swal.fire('Servicio guardado', 'El servicio se ha registrado correctamente', 'success');
+        this.servicioForm.reset();
+      },
+      error: () => {
+        Swal.fire('Error', 'No se pudo guardar el servicio', 'error');
+      }
+    });
+  }
+}

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
@@ -18,7 +18,9 @@
       </mat-form-field>
       <mat-form-field appearance="outline">
         <mat-label>Especialidad</mat-label>
-        <input matInput formControlName="especialidad" />
+        <mat-select formControlName="especialidad">
+          <mat-option *ngFor="let s of servicios" [value]="s.nombre">{{ s.nombre }}</mat-option>
+        </mat-select>
       </mat-form-field>
       <mat-card-actions>
         <button mat-raised-button color="primary" (click)="guardarTecnico()">Guardar Técnico</button>

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TecnicosService } from '../services/tecnicos.service';
+import { ServiciosService } from '../services/servicios.service';
+import { Servicio } from '../models/servicio.model';
 import Swal from 'sweetalert2';
 
 @Component({
@@ -10,8 +12,11 @@ import Swal from 'sweetalert2';
 })
 export class LoadTecnicosComponent implements OnInit {
   tecnicoForm!: FormGroup;
+  servicios: Servicio[] = [];
 
-  constructor(private fb: FormBuilder, private tecnicosService: TecnicosService) {}
+  constructor(private fb: FormBuilder,
+              private tecnicosService: TecnicosService,
+              private serviciosService: ServiciosService) {}
 
   ngOnInit(): void {
     this.tecnicoForm = this.fb.group({
@@ -19,6 +24,11 @@ export class LoadTecnicosComponent implements OnInit {
       apellido: ['', Validators.required],
       codigo: ['', Validators.required],
       especialidad: ['', Validators.required]
+    });
+
+    this.serviciosService.getServicios().subscribe({
+      next: value => this.servicios = value,
+      error: err => console.error('Error al obtener servicios', err)
     });
   }
 

--- a/sistema-tickets-frontend/src/app/models/servicio.model.ts
+++ b/sistema-tickets-frontend/src/app/models/servicio.model.ts
@@ -1,0 +1,4 @@
+export interface Servicio {
+  id: number;
+  nombre: string;
+}

--- a/sistema-tickets-frontend/src/app/services/servicios.service.ts
+++ b/sistema-tickets-frontend/src/app/services/servicios.service.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment.development';
+import { Servicio } from '../models/servicio.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServiciosService {
+  constructor(private http: HttpClient) {}
+
+  getServicios(): Observable<Servicio[]> {
+    return this.http.get<Servicio[]>(`${environment.backendHost}/servicios`);
+  }
+
+  crearServicio(servicio: Servicio): Observable<Servicio> {
+    return this.http.post<Servicio>(`${environment.backendHost}/servicios`, servicio);
+  }
+}


### PR DESCRIPTION
## Summary
- add Servicio entity and repository in backend
- expose `/servicios` endpoints
- create front-end model and service for servicios
- allow creating servicios via new component
- load list of servicios when registering a técnico and use a select
- update navigation to link to servicios

## Testing
- `mvn -q -DskipTests install` *(fails: Could not transfer artifact)*
- `npm run build --silent` *(fails: budget not met)*
- `npm test --silent` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6860e63b5c74832387f8cd73a45daec6