### PR TITLE
Enable automatic ID generation for Tecnico

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/SistemaTicketsBackendApplication.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/SistemaTicketsBackendApplication.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.UUID;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -37,7 +36,6 @@ public class SistemaTicketsBackendApplication {
             if (tecnicoRepository.count() == 0) {
                 List<Tecnico> tecnicos = Arrays.asList(
                     Tecnico.builder()
-                        .id("550e8400-e29b-41d4-a716-446655440000")
                         .nombre("Alexis")
                         .apellido("Gonzalez")
                         .codigo("TE-001")

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Tecnico.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Tecnico.java
@@ -2,6 +2,8 @@ package com.compulandia.sistematickets.entities;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 
 public class Tecnico {
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
 
     private String nombre;


### PR DESCRIPTION
## Summary
- configure Tecnico entity to generate its UUID automatically
- adjust data initialization code to let Hibernate assign IDs

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6860e824ef8c8323aa120c9ad57a6263