### PR TITLE
Fix missing servicios property in LoadTecnicosComponent

### DIFF
--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -26,7 +26,13 @@ export class LoadTecnicosComponent implements OnInit {
       especialidad: ['', Validators.required]
     });
 
+    this.tecnicosService.obtenerProximoCodigo().subscribe(code => {
+      this.tecnicoForm.patchValue({ codigo: code });
+    });
 
+    this.serviciosService.getServicios().subscribe({
+      next: value => (this.servicios = value),
+      error: err => console.error('Error al obtener servicios', err),
     });
   }
 


### PR DESCRIPTION
## Summary
- correctly initialize `servicios` in `LoadTecnicosComponent`
- fetch available servicios on component init
- restore code that autofills technician code

## Testing
- `npm test --silent` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6860eb8ae1388323842e9a90c70b04f1