### PR TITLE
Fix reactive form initialization

### DIFF
--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <mat-card [formGroup]="tecnicoForm" class="tecnico-form">
+  <mat-card *ngIf="tecnicoForm" [formGroup]="tecnicoForm" class="tecnico-form">
     <mat-card-header>
       <mat-card-title>Registrar Técnico</mat-card-title>
     </mat-card-header>


### PR DESCRIPTION
## Summary
- initialize reactive form before usage

## Testing
- `node node_modules/@angular/cli/bin/ng test --watch=false` *(fails: export errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860ee03c7d88323b9e7ca2829adb805