### PR TITLE
Fix tecnico form initialization

### DIFF
--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -17,6 +17,8 @@ export class LoadTecnicosComponent implements OnInit {
   ngOnInit(): void {
     this.tecnicoForm = this.fb.group({
       nombre: ['', Validators.required],
+      apellido: ['', Validators.required],
+      codigo: [''],
       especialidad: ['', Validators.required]
     });
 
@@ -38,7 +40,9 @@ export class LoadTecnicosComponent implements OnInit {
     this.tecnicosService.crearTecnico(this.tecnicoForm.value).subscribe({
       next: (resp) => {
         this.tecnicoForm.reset();
-        // Mostrar mensaje de éxito si quieres
+        this.tecnicosService.obtenerProximoCodigo().subscribe(code => {
+          this.tecnicoForm.patchValue({ codigo: code });
+        });
       },
       error: (err) => {
         console.error('Error al guardar técnico:', err);


### PR DESCRIPTION
## Summary
- include `apellido` and `codigo` fields in LoadTecnicos form
- refresh technician code after saving

## Testing
- `npm test --silent` *(fails: ng permission denied)*
- `npx ng test --watch=false` *(fails: cannot find optional dependency)*
- `node node_modules/@angular/cli/bin/ng test --watch=false` *(fails: cannot find optional dependency)*
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860f38ee4708323a3cc43d2c91699ac