### PR TITLE
Add services field to technician registration

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Usuario.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Usuario.java
@@ -16,5 +16,6 @@ public class Usuario {
     @Id
     private String username;
     private String password;
+    private String servicios;
     private String role;
 }

--- a/sistema-tickets-frontend/src/app/models/usuario.model.ts
+++ b/sistema-tickets-frontend/src/app/models/usuario.model.ts
@@ -1,5 +1,6 @@
 export interface Usuario {
   username: string;
   password: string;
+  servicios?: string;
   role: string;
 }

--- a/sistema-tickets-frontend/src/app/register/register.component.html
+++ b/sistema-tickets-frontend/src/app/register/register.component.html
@@ -10,6 +10,12 @@
         <label for="password">Contraseña</label>
         <input id="password" formControlName="password" type="password" />
       </div>
+      <div class="form-group">
+        <label for="servicios">Servicios</label>
+        <select id="servicios" formControlName="servicios" multiple>
+          <option *ngFor="let s of servicios" [value]="s.nombre">{{ s.nombre }}</option>
+        </select>
+      </div>
       <button type="submit" class="register-button">Registrar</button>
     </form>
   </div>

--- a/sistema-tickets-frontend/src/app/register/register.component.ts
+++ b/sistema-tickets-frontend/src/app/register/register.component.ts
@@ -1,27 +1,49 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
 import { Usuario } from '../models/usuario.model';
+import { ServiciosService } from '../services/servicios.service';
+import { Servicio } from '../models/servicio.model';
 
 @Component({
   selector: 'app-register',
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.css']
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnInit {
   registerForm: FormGroup;
+  servicios: Servicio[] = [];
 
-  constructor(private fb: FormBuilder, private authService: AuthService, private router: Router) {
+  constructor(
+    private fb: FormBuilder,
+    private authService: AuthService,
+    private serviciosService: ServiciosService,
+    private router: Router
+  ) {
     this.registerForm = this.fb.group({
       username: ['', Validators.required],
       password: ['', Validators.required],
+      servicios: [[], Validators.required],
       role: ['TECNICO', Validators.required]
     });
   }
 
+  ngOnInit(): void {
+    this.serviciosService.getServicios().subscribe({
+      next: (data) => (this.servicios = data),
+      error: () => console.error('No se pudieron cargar los servicios')
+    });
+  }
+
   register() {
-    const usuario: Usuario = this.registerForm.value;
+    const formValue = this.registerForm.value;
+    const usuario: Usuario = {
+      username: formValue.username,
+      password: formValue.password,
+      servicios: (formValue.servicios as string[]).join(','),
+      role: formValue.role
+    };
     this.authService.register(usuario).subscribe({
       next: () => this.router.navigateByUrl('/login'),
       error: () => alert('No se pudo registrar')


### PR DESCRIPTION
## Summary
- allow Usuario entity to store `servicios`
- expose list of services in registration form and submit selected services
- adjust client model and component

## Testing
- `mvnw -q test` *(fails: Network is unreachable)*
- `npm test --silent` *(fails: `ng` Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6860f530eca883238f658b3fe941babc