### PR TITLE
Enable multiple specialties per technician

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/SistemaTicketsBackendApplication.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/SistemaTicketsBackendApplication.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Bean;
 
 import com.compulandia.sistematickets.entities.Tecnico;
 import com.compulandia.sistematickets.entities.Ticket;
+import com.compulandia.sistematickets.entities.Servicio;
 import com.compulandia.sistematickets.enums.TicketStatus;
 import com.compulandia.sistematickets.enums.TypeTicket;
 import com.compulandia.sistematickets.repository.TecnicoRepository;
@@ -39,7 +40,9 @@ public class SistemaTicketsBackendApplication {
                         .nombre("Alexis")
                         .apellido("Gonzalez")
                         .codigo("TE-001")
-                        .especialidad("Desarrollo Backend")
+                        .especialidades(Arrays.asList(
+                            Servicio.builder().nombre("Desarrollo Backend").build()
+                        ))
                         .build()
                     // ... otros técnicos
                 );

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Tecnico.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Tecnico.java
@@ -5,6 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import java.util.List;
+
+import com.compulandia.sistematickets.entities.Servicio;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,7 +33,13 @@ public class Tecnico {
     @Column(unique = true)
     private String codigo;
 
-    private String especialidad;
+    @ManyToMany(cascade = jakarta.persistence.CascadeType.ALL)
+    @JoinTable(
+        name = "tecnico_servicio",
+        joinColumns = @JoinColumn(name = "tecnico_id"),
+        inverseJoinColumns = @JoinColumn(name = "servicio_id")
+    )
+    private List<Servicio> especialidades;
 
     private String foto;
 

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/ServicioRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/ServicioRepository.java
@@ -7,4 +7,5 @@ import com.compulandia.sistematickets.entities.Servicio;
 
 @Repository
 public interface ServicioRepository extends JpaRepository<Servicio, Long> {
+    Servicio findByNombre(String nombre);
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TecnicoRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TecnicoRepository.java
@@ -11,6 +11,6 @@ import com.compulandia.sistematickets.entities.Tecnico;
 public interface TecnicoRepository extends JpaRepository<Tecnico, String> {
     Tecnico findByCodigo(String codigo);
 
-    List<Tecnico> findByEspecialidad(String especialidad);
+    List<Tecnico> findByEspecialidadesNombre(String nombre);
 
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.compulandia.sistematickets.entities.Tecnico;
+import com.compulandia.sistematickets.entities.Servicio;
 import com.compulandia.sistematickets.repository.TecnicoRepository;
+import com.compulandia.sistematickets.repository.ServicioRepository;
 
 @RestController
 @CrossOrigin("*")
@@ -17,8 +19,20 @@ public class TecnicoController {
     @Autowired
     private TecnicoRepository tecnicoRepository;
 
+    @Autowired
+    private ServicioRepository servicioRepository;
+
     @PostMapping("/tecnicos")
     public Tecnico saveTecnico(@RequestBody Tecnico tecnico) {
+        if (tecnico.getEspecialidades() != null) {
+            tecnico.setEspecialidades(
+                tecnico.getEspecialidades().stream()
+                    .map(s -> {
+                        Servicio existing = servicioRepository.findByNombre(s.getNombre());
+                        return existing != null ? existing : servicioRepository.save(s);
+                    })
+                    .toList());
+        }
         return tecnicoRepository.save(tecnico);
     }
 

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -50,7 +50,7 @@ public class TicketController {
     }
     @GetMapping("/tecnicosPorEspecialidad")
     public List<Tecnico> listarTecnicosPorEspecialidad(@RequestParam String especialidad){
-        return tecnicoRepository.findByEspecialidad(especialidad);
+        return tecnicoRepository.findByEspecialidadesNombre(especialidad);
     }
 
     @GetMapping("/tickets")

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
@@ -17,9 +17,9 @@
         <input matInput formControlName="codigo" readonly />
       </mat-form-field>
       <mat-form-field appearance="outline">
-        <mat-label>Especialidad</mat-label>
-        <mat-select formControlName="especialidad">
-          <mat-option *ngFor="let s of servicios" [value]="s.nombre">{{ s.nombre }}</mat-option>
+        <mat-label>Especialidades</mat-label>
+        <mat-select formControlName="especialidades" multiple>
+          <mat-option *ngFor="let s of servicios" [value]="s">{{ s.nombre }}</mat-option>
         </mat-select>
       </mat-form-field>
       <mat-card-actions>

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -20,7 +20,7 @@ export class LoadTecnicosComponent implements OnInit {
       nombre: ['', Validators.required],
       apellido: ['', Validators.required],
       codigo: [''],
-      especialidad: ['', Validators.required]
+      especialidades: [[], Validators.required]
     });
 
     this.tecnicosService.obtenerProximoCodigo().subscribe(code => {

--- a/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
+++ b/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
@@ -1,9 +1,11 @@
+import { Servicio } from './servicio.model';
+
 export interface Tecnico {
     id: string;
     codigo: string;
     nombre: string;
     apellido: string;
-    especialidad: string;
+    especialidades: Servicio[];
     foto: string;
 }
 

--- a/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.html
@@ -15,7 +15,7 @@
                         <th>Nombre</th>
                         <th>Apellido</th>
                         <th>Codigo</th>
-                        <th>Especialidad</th>
+                        <th>Especialidades</th>
                         <th>Tickets</th>
                     </tr>
                 </thead>
@@ -25,7 +25,7 @@
                         <td>{{ tecnico.nombre }}</td>
                         <td>{{ tecnico.apellido }}</td>
                         <td>{{ tecnico.codigo }}</td>
-                        <td>{{ tecnico.especialidad }}</td>
+                        <td>{{ tecnico.especialidades?.map(e => e.nombre).join(', ') }}</td>
                         <td>
                             <button mat-raised-button
                                 (click)="listarTicketsDeTecnico(tecnico)">Ver
@@ -76,11 +76,11 @@
                         <td mat-cell
                             *matCellDef="let tecnico">{{tecnico.codigo}}</td>
                     </ng-container>
-                    <ng-container matColumnDef="especialidad">
+                    <ng-container matColumnDef="especialidades">
                         <th mat-header-cell *matHeaderCellDef mat-sort-header>
-                            ESPECIALIDAD </th>
+                            ESPECIALIDADES </th>
                         <td mat-cell
-                            *matCellDef="let tecnico">{{tecnico.especialidad}}</td>
+                            *matCellDef="let tecnico">{{tecnico.especialidades?.map(e => e.nombre).join(', ')}}</td>
                     </ng-container>
 
                     <ng-container matColumnDef="tickets">

--- a/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.ts
@@ -16,7 +16,7 @@ export class TecnicosComponent implements OnInit {
 
   tecnicos!: Array<Tecnico>;
   tecnicosDataSource!: MatTableDataSource<Tecnico>;
-  displayedColumns: string[] = ['id', 'nombre', 'apellido', 'codigo', 'especialidad','tickets'];
+  displayedColumns: string[] = ['id', 'nombre', 'apellido', 'codigo', 'especialidades','tickets'];
 
   constructor(private tecnicoService: TecnicosService, private router: Router) { }
 


### PR DESCRIPTION
## Summary
- update Tecnico entity to use many-to-many Servicios
- map specialties when saving technicians
- adjust repository and controllers for new relationship
- adapt Angular models and components for multiple specialties

## Testing
- `mvn test` *(fails: `mvn: command not found`)*
- `npm test` *(fails: `ng: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_68616ea42c408323a59d07b5e39e341a