### PR TITLE
Add login credentials fields to technician form

### DIFF
--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
@@ -22,6 +22,14 @@
           <mat-option *ngFor="let s of servicios" [value]="s.nombre">{{ s.nombre }}</mat-option>
         </mat-select>
       </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Nombre de usuario</mat-label>
+        <input matInput formControlName="username" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Contraseña</mat-label>
+        <input matInput type="password" formControlName="password" />
+      </mat-form-field>
       <mat-card-actions>
         <button mat-raised-button color="primary" (click)="guardarTecnico()">Guardar Técnico</button>
       </mat-card-actions>

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -3,6 +3,8 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TecnicosService } from '../services/tecnicos.service';
 import { ServiciosService } from '../services/servicios.service';
 import { Servicio } from '../models/servicio.model';
+import { AuthService } from '../services/auth.service';
+import { Usuario } from '../models/usuario.model';
 
 @Component({
   selector: 'app-load-tecnicos',
@@ -13,14 +15,21 @@ export class LoadTecnicosComponent implements OnInit {
   tecnicoForm!: FormGroup;
   servicios: Servicio[] = [];
 
-  constructor(private fb: FormBuilder, private tecnicosService: TecnicosService, private servicioServices: ServiciosService) {}
+  constructor(
+    private fb: FormBuilder,
+    private tecnicosService: TecnicosService,
+    private servicioServices: ServiciosService,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {
     this.tecnicoForm = this.fb.group({
       nombre: ['', Validators.required],
       apellido: ['', Validators.required],
       codigo: [''],
-      especialidad: ['', Validators.required]
+      especialidad: ['', Validators.required],
+      username: ['', Validators.required],
+      password: ['', Validators.required]
     });
 
     this.tecnicosService.obtenerProximoCodigo().subscribe(code => {
@@ -37,9 +46,20 @@ export class LoadTecnicosComponent implements OnInit {
     if (!this.tecnicoForm || this.tecnicoForm.invalid) {
       return;
     }
+    const { nombre, apellido, codigo, especialidad, username, password } = this.tecnicoForm.value;
+    const tecnico = { nombre, apellido, codigo, especialidad } as any;
 
-    this.tecnicosService.crearTecnico(this.tecnicoForm.value).subscribe({
-      next: (resp) => {
+    this.tecnicosService.crearTecnico(tecnico).subscribe({
+      next: () => {
+        const usuario: Usuario = {
+          username,
+          password,
+          servicios: especialidad,
+          role: 'TECNICO'
+        };
+        this.authService.register(usuario).subscribe({
+          error: err => console.error('Error al registrar usuario:', err)
+        });
         this.tecnicoForm.reset();
         this.tecnicosService.obtenerProximoCodigo().subscribe(code => {
           this.tecnicoForm.patchValue({ codigo: code });


### PR DESCRIPTION
## Summary
- extend technician registration to ask for a username and password
- register technicians as users along with their technician data

## Testing
- `node node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68616f04a018832387d78513946c183b