### PR TITLE
Fix tecnico listing lazy init

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Tecnico.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Tecnico.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.FetchType;
 import java.util.List;
 
 import com.compulandia.sistematickets.entities.Servicio;
@@ -33,7 +34,7 @@ public class Tecnico {
     @Column(unique = true)
     private String codigo;
 
-    @ManyToMany(cascade = jakarta.persistence.CascadeType.ALL)
+    @ManyToMany(fetch = FetchType.EAGER, cascade = jakarta.persistence.CascadeType.ALL)
     @JoinTable(
         name = "tecnico_servicio",
         joinColumns = @JoinColumn(name = "tecnico_id"),


### PR DESCRIPTION
## Summary
- load tecnico specialities eagerly so listing works

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `./mvnw test` *(fails: could not resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68618a94350883239baddadab351bded