### PR TITLE
Fix saveTecnico transaction

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.transaction.Transactional;
 
 import com.compulandia.sistematickets.entities.Tecnico;
 import com.compulandia.sistematickets.entities.Servicio;
@@ -23,6 +24,7 @@ public class TecnicoController {
     private ServicioRepository servicioRepository;
 
     @PostMapping("/tecnicos")
+    @Transactional
     public Tecnico saveTecnico(@RequestBody Tecnico tecnico) {
         if (tecnico.getEspecialidades() != null) {
             tecnico.setEspecialidades(


### PR DESCRIPTION
## Summary
- keep Servicio entities in the persistence context when saving technicians

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6861eeee169083239d32b26b0e96d891