### PR TITLE
Add SweetAlert confirmation for new technician

### DIFF
--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -3,6 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { TecnicosService } from '../services/tecnicos.service';
 import { ServiciosService } from '../services/servicios.service';
 import { Servicio } from '../models/servicio.model';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-load-tecnicos',
@@ -40,6 +41,7 @@ export class LoadTecnicosComponent implements OnInit {
 
     this.tecnicosService.crearTecnico(this.tecnicoForm.value).subscribe({
       next: (resp) => {
+        Swal.fire('Técnico guardado', 'El técnico se ha registrado correctamente', 'success');
         this.tecnicoForm.reset();
         this.tecnicosService.obtenerProximoCodigo().subscribe(code => {
           this.tecnicoForm.patchValue({ codigo: code });
@@ -47,6 +49,7 @@ export class LoadTecnicosComponent implements OnInit {
       },
       error: (err) => {
         console.error('Error al guardar técnico:', err);
+        Swal.fire('Error', 'No se pudo guardar el técnico', 'error');
       }
     });
   }


### PR DESCRIPTION
## Summary
- show a success message when a technician is saved

## Testing
- `node ./node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless --no-progress --code-coverage` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `node ./node_modules/@angular/cli/bin/ng build --no-progress` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6861f16ec1488323b885cb5ec0726717