### PR TITLE
Fix ticket creation API

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.compulandia.sistematickets.entities.Tecnico;
 import com.compulandia.sistematickets.entities.Ticket;
@@ -82,7 +84,7 @@ public class TicketController {
 public Ticket guardarTicket(
     @RequestParam(value="file", required=false) MultipartFile file,
     @RequestParam("cantidad") double cantidad,
-    @RequestParam("type") TypeTicket type,
+    @RequestParam("type") String type,
     @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
     @RequestParam("codigoTecnico") String codigoTecnico,
     @RequestParam(value="instalacionEquipo", required = false) String instalacionEquipo,
@@ -98,10 +100,16 @@ public Ticket guardarTicket(
     @RequestParam(value="diagnosticoProblema", required = false) String diagnosticoProblema,
     @RequestParam(value="diagnosticoObservaciones", required = false) String diagnosticoObservaciones
 ) throws IOException {
+    TypeTicket typeTicket;
+    try {
+        typeTicket = TypeTicket.valueOf(type.toUpperCase());
+    } catch (IllegalArgumentException e) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Tipo de ticket inválido");
+    }
     return ticketService.saveTicket(
         file,
         cantidad,
-        type,
+        typeTicket,
         date,
         codigoTecnico,
         instalacionEquipo,


### PR DESCRIPTION
## Summary
- allow `/tickets` endpoint to accept a string for `type` and convert it to the `TypeTicket` enum

## Testing
- `npm test` *(fails: `ng` permission denied)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM because repository is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68620ee474d08323993e262787b6e2bd