### PR TITLE
Auto-assign technicians by service

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import com.compulandia.sistematickets.enums.TicketStatus;
 import com.compulandia.sistematickets.enums.TypeTicket;
+import com.compulandia.sistematickets.entities.Servicio;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -55,4 +56,7 @@ public class Ticket {
     
     @ManyToOne
     private Tecnico tecnico;
+
+    @ManyToOne
+    private Servicio servicio;
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -84,9 +84,8 @@ public class TicketController {
 public Ticket guardarTicket(
     @RequestParam(value="file", required=false) MultipartFile file,
     @RequestParam("cantidad") double cantidad,
-    @RequestParam("type") String type,
+    @RequestParam("servicio") String servicio,
     @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-    @RequestParam("codigoTecnico") String codigoTecnico,
     @RequestParam(value="instalacionEquipo", required = false) String instalacionEquipo,
     @RequestParam(value="instalacionModelo", required = false) String instalacionModelo,
     @RequestParam(value="instalacionDireccion", required = false) String instalacionDireccion,
@@ -100,18 +99,11 @@ public Ticket guardarTicket(
     @RequestParam(value="diagnosticoProblema", required = false) String diagnosticoProblema,
     @RequestParam(value="diagnosticoObservaciones", required = false) String diagnosticoObservaciones
 ) throws IOException {
-    TypeTicket typeTicket;
-    try {
-        typeTicket = TypeTicket.valueOf(type.toUpperCase());
-    } catch (IllegalArgumentException e) {
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Tipo de ticket inválido");
-    }
     return ticketService.saveTicket(
         file,
         cantidad,
-        typeTicket,
+        servicio,
         date,
-        codigoTecnico,
         instalacionEquipo,
         instalacionModelo,
         instalacionDireccion,

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -38,7 +38,7 @@ const routes: Routes = [
       { path: "tecnicos", component: TecnicosComponent },
       { path: "tickets", component: TicketsComponent },
       { path: "tecnico-detalles/:codigo",  component: TecnicoDetallesComponent },
-      { path: "new-ticket/:codigoTecnico", component: NewTicketComponent }
+      { path: "new-ticket", component: NewTicketComponent }
     ]
   }, // Assuming admin redirects to home
 

--- a/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.html
+++ b/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.html
@@ -17,7 +17,7 @@
             </mat-form-field>
             <mat-form-field appearance="outline">
                 <mat-label>Tipo de Servicio</mat-label>
-                <mat-select formControlName="type">
+                <mat-select formControlName="servicio">
                     <mat-option *ngFor="let servicio of servicios" [value]="servicio.nombre">{{ servicio.nombre }}</mat-option>
                 </mat-select>
             </mat-form-field>
@@ -81,10 +81,6 @@
                     <input matInput formControlName="diagnosticoObservaciones" />
                 </mat-form-field>
             </div>
-            <mat-form-field appearance="outline">
-                <mat-label>Código Técnico</mat-label>
-                <input matInput formControlName="codigoTecnico" [value]="codigoTecnico" readonly />
-            </mat-form-field>
             <mat-form-field appearance="outline">
                 <mat-label>Archivo</mat-label>
                 <input matInput readonly formControlName="fileName">

--- a/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.ts
+++ b/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { Form, FormBuilder, FormGroup } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
 import { TecnicosService } from '../services/tecnicos.service';
 import { ServiciosService } from '../services/servicios.service';
 import { Servicio } from '../models/servicio.model';
@@ -12,13 +11,11 @@ import Swal from 'sweetalert2';
 })
 export class NewTicketComponent implements OnInit{
   ticketFormGroup!: FormGroup;
-  codigoTecnico!: string;
   servicios: Servicio[] = [];
   pdfFileUrl!: string;
   // Fields specific to each type of servicio will be handled through the reactive form
   constructor(
     private fb: FormBuilder,
-    private activatedRoute: ActivatedRoute,
     private tecnicoService: TecnicosService,
     private servicioService: ServiciosService
   ) {
@@ -31,12 +28,10 @@ export class NewTicketComponent implements OnInit{
     error: err => console.error('Error al cargar servicios', err)
   });
 
-  this.codigoTecnico = this.activatedRoute.snapshot.params['codigoTecnico'];
   this.ticketFormGroup = this.fb.group({
     date: this.fb.control(''),
     cantidad: this.fb.control(''),
-    type: this.fb.control(''),
-    codigoTecnico: this.fb.control(this.codigoTecnico),
+    servicio: this.fb.control(''),
     fileSource: this.fb.control(null),
     fileName: this.fb.control(''),
     // Campos para Instalación
@@ -78,8 +73,7 @@ guardarTicket() {
   let formData = new FormData();
   formData.set('date', formattedDate);
   formData.set('cantidad', this.ticketFormGroup.value.cantidad);
-  formData.set('type', this.ticketFormGroup.value.type);
-  formData.set('codigoTecnico', this.ticketFormGroup.value.codigoTecnico);
+  formData.set('servicio', this.ticketFormGroup.value.servicio);
   if (this.ticketFormGroup.value.fileSource) {
     formData.append('file', this.ticketFormGroup.value.fileSource);
   }

--- a/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.ts
@@ -36,7 +36,7 @@ export class TecnicoDetallesComponent {
   }
 
   agregaTicket() {
-    this.router.navigateByUrl(`admin/new-ticket/${this.tecnicoCodigo}`);
+    this.router.navigateByUrl(`admin/new-ticket`);
 
   }
 }


### PR DESCRIPTION
## Summary
- add `Servicio` reference to `Ticket`
- choose technician according to service in `TicketService`
- adjust ticket controller to take `servicio` instead of technician code
- update frontend ticket form and routing to remove technician code
- tweak technician details view navigation

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `npm test` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686211e74e04832393dceccdfbcf674f