### PR TITLE
Add technician ticket actions

### DIFF
--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -38,4 +38,14 @@ export class TecnicosService {
   public guardarTicket(formData: any): Observable<Ticket> {
     return this.http.post<Ticket>(`${environment.backendHost}/tickets`, formData);
   }
+
+  public actualizarEstadoTicket(id: number, status: string): Observable<Ticket> {
+    return this.http.put<Ticket>(
+      `${environment.backendHost}/tickets/${id}/actualizarTicket`,
+      null,
+      {
+        params: { status }
+      }
+    );
+  }
 }

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
@@ -53,6 +53,14 @@
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
         <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
       </ng-container>
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
+        <td mat-cell *matCellDef="let element">
+          <button mat-button color="primary" *ngIf="element.status === 'PENDIENTE'" (click)="marcarEnProceso(element)">Iniciar</button>
+          <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
+          <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+        </td>
+      </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
@@ -84,6 +92,14 @@
       <ng-container matColumnDef="nombre">
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
         <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+      </ng-container>
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
+        <td mat-cell *matCellDef="let element">
+          <button mat-button color="primary" *ngIf="element.status === 'PENDIENTE'" (click)="marcarEnProceso(element)">Iniciar</button>
+          <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
+          <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+        </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
@@ -117,6 +133,13 @@
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
         <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
       </ng-container>
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
+        <td mat-cell *matCellDef="let element">
+          <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
+          <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+        </td>
+      </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
@@ -148,6 +171,14 @@
       <ng-container matColumnDef="nombre">
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
         <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+      </ng-container>
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
+        <td mat-cell *matCellDef="let element">
+          <button mat-button color="primary" *ngIf="element.status === 'PENDIENTE'" (click)="marcarEnProceso(element)">Iniciar</button>
+          <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
+          <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+        </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -22,7 +22,7 @@ export class TecnicoDashboardComponent implements OnInit {
   completedDataSource = new MatTableDataSource<Ticket>();
   allDataSource = new MatTableDataSource<Ticket>();
 
-  displayedColumns: string[] = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre'];
+  displayedColumns: string[] = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre', 'acciones'];
 
   activeCategory = '';
   statusChart?: Chart;
@@ -95,5 +95,27 @@ export class TecnicoDashboardComponent implements OnInit {
     if (this.activeCategory === 'metrics') {
       setTimeout(() => this.initializeChart());
     }
+  }
+
+  actualizarEstado(ticket: Ticket, status: string) {
+    this.tecnicosService.actualizarEstadoTicket(ticket.id, status).subscribe({
+      next: (t) => {
+        ticket.status = status;
+        this.filterTickets();
+      },
+      error: (err) => console.error('Error al actualizar ticket', err)
+    });
+  }
+
+  marcarEnProceso(ticket: Ticket) {
+    this.actualizarEstado(ticket, 'EN_PROCESO');
+  }
+
+  finalizarTicket(ticket: Ticket) {
+    this.actualizarEstado(ticket, 'FINALIZADO');
+  }
+
+  cancelarTicket(ticket: Ticket) {
+    this.actualizarEstado(ticket, 'CANCELADO');
   }
 }


### PR DESCRIPTION
## Summary
- add service call to update ticket status
- display action buttons in technician dashboard tables
- handle status updates from dashboard

## Testing
- `npm test` *(fails: ng permission denied)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68621612a3bc83238d5bb4abb2e07243