### PR TITLE
Restrict access by role

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/SistemaTicketsBackendApplication.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/SistemaTicketsBackendApplication.java
@@ -15,10 +15,12 @@ import org.springframework.context.annotation.Bean;
 import com.compulandia.sistematickets.entities.Tecnico;
 import com.compulandia.sistematickets.entities.Ticket;
 import com.compulandia.sistematickets.entities.Servicio;
+import com.compulandia.sistematickets.entities.Usuario;
 import com.compulandia.sistematickets.enums.TicketStatus;
 import com.compulandia.sistematickets.enums.TypeTicket;
 import com.compulandia.sistematickets.repository.TecnicoRepository;
 import com.compulandia.sistematickets.repository.TicketRepository;
+import com.compulandia.sistematickets.repository.UsuarioRepository;
 
 import jakarta.transaction.Transactional;
 
@@ -31,8 +33,15 @@ public class SistemaTicketsBackendApplication {
 
     @Bean
     @Transactional
-    CommandLineRunner initData(TecnicoRepository tecnicoRepository, TicketRepository ticketRepository) {
+    CommandLineRunner initData(TecnicoRepository tecnicoRepository, TicketRepository ticketRepository, UsuarioRepository usuarioRepository) {
         return args -> {
+            if (usuarioRepository.count() == 0) {
+                usuarioRepository.save(Usuario.builder()
+                    .username("admin")
+                    .password("admin")
+                    .role("ADMIN")
+                    .build());
+            }
             // Verificar si ya existen datos para no duplicar
             if (tecnicoRepository.count() == 0) {
                 List<Tecnico> tecnicos = Arrays.asList(

--- a/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
+++ b/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
@@ -3,10 +3,10 @@
         <mat-icon>menu</mat-icon>
     </button>
     <span style="flex:auto">Admin Dashboard</span>
-    <button mat-button routerLink="/admin/home">Home</button>
-    <button mat-button routerLink="/admin/profile">Perfil</button>
+    <button mat-button routerLink="/admin/home" *ngIf="authService.roles.includes('ADMIN')">Home</button>
+    <button mat-button routerLink="/admin/profile" *ngIf="authService.roles.includes('ADMIN')">Perfil</button>
 
-    <button  mat-button [matMenuTriggerFor]="importMenu">
+    <button  mat-button [matMenuTriggerFor]="importMenu" *ngIf="authService.roles.includes('ADMIN')">
         <mat-icon iconPositionEnd>keyboard_arrow_down</mat-icon>
         Importar
     </button>
@@ -32,36 +32,36 @@
 <mat-drawer-container>
     <mat-drawer #myDrawer opened="true" mode="side" position="start">
     <mat-list>
-        <mat-list-item>
+        <mat-list-item *ngIf="authService.roles.includes('ADMIN')">
             <button mat-button routerLink="/admin/dashboard">
                 <mat-icon>dashboard</mat-icon>
                 Dashboard
             </button>
         </mat-list-item>
-        <mat-list-item>
+        <mat-list-item *ngIf="authService.roles.includes('ADMIN') || authService.roles.includes('TECNICO')">
             <button mat-button routerLink="/admin/dashboard-tecnico">
                 <mat-icon>dashboard</mat-icon>
                 Dashboard Tecnico
             </button>
         </mat-list-item>
-        <mat-list-item>
+        <mat-list-item *ngIf="authService.roles.includes('ADMIN')">
              <button mat-button routerLink="/admin/tecnicos">
                 <mat-icon>Dasboard</mat-icon>
                 Tecnicos
              </button>
         </mat-list-item>
-        <mat-list-item>
+        <mat-list-item *ngIf="authService.roles.includes('ADMIN')">
              <button mat-button routerLink="/admin/loadServicios">
                 <mat-icon>Dasboard</mat-icon>
                 Servicios
              </button>
         </mat-list-item>
-        <mat-list-item>
+        <mat-list-item *ngIf="authService.roles.includes('ADMIN')">
              <button mat-button routerLink="/admin/tickets">
                 <mat-icon>Dasboard</mat-icon>
                 Tickets
              </button>
-             
+
         </mat-list-item>
     </mat-list>
     </mat-drawer>

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -21,26 +21,78 @@ const routes: Routes = [
   { path: "", component: LoginComponent },
   { path: "login", component: LoginComponent },
   {
-    path: "admin", component: AdminTemplateComponent,
-    canActivate: [AuthGuard], // Assuming AuthGuard is imported and provided in the module
+    path: "admin",
+    component: AdminTemplateComponent,
+    canActivate: [AuthGuard],
     children: [
-      { path: "home", component: HomeComponent },
-      { path: "profile", component: ProfileComponent },
-      { path: "loadTecnicos", component: LoadTecnicosComponent,
-       },
-      { path: "loadServicios", component: LoadServiciosComponent,
-       },
-
-      { path: "loadTickets", component: LoadTicketsComponent,
-       },
-      { path: "dashboard", component: DashboardComponent },
-      { path: "dashboard-tecnico", component: TecnicoDashboardComponent },
-      { path: "tecnicos", component: TecnicosComponent },
-      { path: "tickets", component: TicketsComponent },
-      { path: "tecnico-detalles/:codigo",  component: TecnicoDetallesComponent },
-      { path: "new-ticket", component: NewTicketComponent }
+      {
+        path: "home",
+        component: HomeComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "profile",
+        component: ProfileComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "loadTecnicos",
+        component: LoadTecnicosComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "loadServicios",
+        component: LoadServiciosComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "loadTickets",
+        component: LoadTicketsComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "dashboard",
+        component: DashboardComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "dashboard-tecnico",
+        component: TecnicoDashboardComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN", "TECNICO"] }
+      },
+      {
+        path: "tecnicos",
+        component: TecnicosComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "tickets",
+        component: TicketsComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "tecnico-detalles/:codigo",
+        component: TecnicoDetallesComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "new-ticket",
+        component: NewTicketComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      }
     ]
-  }, // Assuming admin redirects to home
+  },
 
 ];
 


### PR DESCRIPTION
## Summary
- seed default admin user in backend `initData`
- restrict Angular routes to admin or technician roles
- hide menu items based on authenticated role

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent -- --watch=false` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68629edd04908323bee06b57566d6fdb