### PR TITLE
Show user specific tickets

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Usuario.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Usuario.java
@@ -18,4 +18,7 @@ public class Usuario {
     private String password;
     private String servicios;
     private String role;
+
+    // Codigo del tecnico asociado (opcional)
+    private String codigoTecnico;
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TecnicoController.java
@@ -56,6 +56,7 @@ public class TecnicoController {
                     .username(dto.getUsername())
                     .password(dto.getPassword())
                     .role("TECNICO")
+                    .codigoTecnico(dto.getCodigo())
                     .build();
             usuarioRepository.save(usuario);
         }

--- a/sistema-tickets-frontend/src/app/login/login.component.ts
+++ b/sistema-tickets-frontend/src/app/login/login.component.ts
@@ -25,7 +25,13 @@ export class LoginComponent implements OnInit {
     const username = this.loginForm.value.username;
     const password = this.loginForm.value.password;
     this.authService.login(username, password).subscribe({
-      next: () => this.router.navigateByUrl('/admin'),
+      next: () => {
+        if (this.authService.roles.includes('TECNICO')) {
+          this.router.navigateByUrl('/admin/dashboard-tecnico');
+        } else {
+          this.router.navigateByUrl('/admin');
+        }
+      },
       error: () => alert('Credenciales incorrectas')
     });
   }

--- a/sistema-tickets-frontend/src/app/models/usuario.model.ts
+++ b/sistema-tickets-frontend/src/app/models/usuario.model.ts
@@ -3,4 +3,5 @@ export interface Usuario {
   password: string;
   servicios?: string;
   role: string;
+  codigoTecnico?: string;
 }

--- a/sistema-tickets-frontend/src/app/services/auth.service.ts
+++ b/sistema-tickets-frontend/src/app/services/auth.service.ts
@@ -11,6 +11,7 @@ import { Usuario } from '../models/usuario.model';
 export class AuthService {
 
 public username: any;
+public codigoTecnico: string | undefined;
 public isAuthenticated: boolean = false;
 public roles: string[] = [];
 
@@ -23,6 +24,7 @@ public roles: string[] = [];
         tap((user: Usuario) => {
           this.username = user.username;
           this.roles = [user.role];
+          this.codigoTecnico = user.codigoTecnico;
           this.isAuthenticated = true;
         }),
         map(() => true)
@@ -37,6 +39,7 @@ public roles: string[] = [];
     this.isAuthenticated = false;
     this.roles = [];
     this.username = undefined;
+    this.codigoTecnico = undefined;
     this.router.navigateByUrl("/login");
   }
 }

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -30,7 +30,7 @@ export class TecnicoDashboardComponent implements OnInit {
   constructor(private tecnicosService: TecnicosService, private authService: AuthService) {}
 
   ngOnInit(): void {
-    this.tecnicoCodigo = this.authService.username;
+    this.tecnicoCodigo = this.authService.codigoTecnico || this.authService.username;
     if (!this.tecnicoCodigo) {
       return;
     }


### PR DESCRIPTION
## Summary
- link technician accounts to their user accounts in backend
- register technician code on user entity when creating a technician
- expose technician code to frontend AuthService
- store technician code after login and load tickets with it
- route technicians directly to their dashboard after login

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `npm test` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6862bc5178308323a7d1a03bf9f98418