### PR TITLE
Improve technician dashboard

### DIFF
--- a/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
+++ b/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
@@ -25,6 +25,7 @@
 
     <button mat-button *ngIf="authService.isAuthenticated">
         {{ authService.username }}
+        <span *ngIf="authService.codigoTecnico">({{ authService.codigoTecnico }})</span>
     </button>
 
     <button mat-raised-button class="custom-accent" (click)="logout()">Salir</button>

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
@@ -5,6 +5,11 @@
   background-color: #f9f9f9;
 }
 
+.tech-header {
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+}
+
 .card-container {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
@@ -1,4 +1,5 @@
 <div class="dashboard-container">
+  <h2 class="tech-header">Código Técnico: {{ tecnicoCodigo }}</h2>
   <div class="card-container">
     <mat-card class="card today" (click)="setCategory('today')">
       <mat-card-title>Tickets del día</mat-card-title>

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -30,7 +30,7 @@ export class TecnicoDashboardComponent implements OnInit {
   constructor(private tecnicosService: TecnicosService, private authService: AuthService) {}
 
   ngOnInit(): void {
-    this.tecnicoCodigo = this.authService.codigoTecnico || this.authService.username;
+    this.tecnicoCodigo = this.authService.codigoTecnico;
     if (!this.tecnicoCodigo) {
       return;
     }
@@ -38,6 +38,7 @@ export class TecnicoDashboardComponent implements OnInit {
       next: (data) => {
         this.tickets = data;
         this.filterTickets();
+        this.activeCategory = 'pending';
       },
       error: (err) => {
         console.error('Error al cargar los tickets', err);


### PR DESCRIPTION
## Summary
- show technician code next to username in admin template
- display technician code in dashboard header
- automatically show pending tickets when dashboard loads

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: `ng: Permission denied`)*
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686350a65e5c8323a5edc862b5329765