### PR TITLE
Fix ticket type mapping

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -80,6 +80,13 @@ public class TicketService {
             servicio = servicioRepository.save(Servicio.builder().nombre(servicioNombre).build());
         }
 
+        TypeTicket typeTicket = null;
+        try {
+            typeTicket = TypeTicket.valueOf(servicioNombre.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            // El nombre del servicio no corresponde con ningún TypeTicket definido
+        }
+
         Tecnico tecnico = null;
         if (tecnicoCodigo != null && !tecnicoCodigo.isEmpty()) {
             tecnico = tecnicoRepository.findByCodigo(tecnicoCodigo);
@@ -96,6 +103,7 @@ public class TicketService {
                 .fecha(date)
                 .tecnico(tecnico)
                 .servicio(servicio)
+                .type(typeTicket)
                 .cantidad(cantidad)
                 .file(filePath != null ? filePath.toUri().toString() : null)
                 .instalacionEquipo(instalacionEquipo)

--- a/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
+++ b/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
@@ -19,6 +19,7 @@ export interface Ticket {
     status: string;
     file: string;
     tecnico: Tecnico;
+    servicio?: Servicio;
     instalacionEquipo?: string;
     instalacionModelo?: string;
     instalacionDireccion?: string;


### PR DESCRIPTION
## Summary
- map ticket `type` from the selected service name when creating tickets
- expose optional `servicio` on the Ticket model so frontend tables match the API

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM for spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6863610d450c8323afc7d810fbb0e84f