### PR TITLE
Add admin dashboard charts

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/dto/TicketStatsDto.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/dto/TicketStatsDto.java
@@ -1,0 +1,13 @@
+package com.compulandia.sistematickets.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketStatsDto {
+    private String label;
+    private Long count;
+}

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
@@ -3,6 +3,7 @@ package com.compulandia.sistematickets.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.compulandia.sistematickets.entities.Ticket;
@@ -16,5 +17,14 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     List<Ticket> findByStatus(TicketStatus status);
 
     List<Ticket> findByType(TypeTicket typeTicket);
+
+    @Query(value = "SELECT fecha as label, COUNT(*) as count FROM ticket GROUP BY fecha ORDER BY fecha", nativeQuery = true)
+    List<Object[]> countTicketsByDay();
+
+    @Query(value = "SELECT CONCAT(YEAR(fecha), '-W', WEEK(fecha, 1)) as label, COUNT(*) as count FROM ticket GROUP BY YEAR(fecha), WEEK(fecha, 1) ORDER BY YEAR(fecha), WEEK(fecha, 1)", nativeQuery = true)
+    List<Object[]> countTicketsByWeek();
+
+    @Query(value = "SELECT DATE_FORMAT(fecha, '%Y-%m') as label, COUNT(*) as count FROM ticket GROUP BY DATE_FORMAT(fecha, '%Y-%m') ORDER BY DATE_FORMAT(fecha, '%Y-%m')", nativeQuery = true)
+    List<Object[]> countTicketsByMonth();
 
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.UUID;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import com.compulandia.sistematickets.enums.TypeTicket;
 import com.compulandia.sistematickets.repository.TecnicoRepository;
 import com.compulandia.sistematickets.repository.TicketRepository;
 import com.compulandia.sistematickets.repository.ServicioRepository;
+import com.compulandia.sistematickets.dto.TicketStatsDto;
 
 import jakarta.transaction.Transactional;
 
@@ -142,5 +144,23 @@ public class TicketService {
         Ticket ticket = ticketRepository.findById(id).get();
         ticket.setStatus(status);
         return ticketRepository.save(ticket);
+    }
+
+    public List<TicketStatsDto> getStatsByDay() {
+        return ticketRepository.countTicketsByDay().stream()
+                .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
+                .toList();
+    }
+
+    public List<TicketStatsDto> getStatsByWeek() {
+        return ticketRepository.countTicketsByWeek().stream()
+                .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
+                .toList();
+    }
+
+    public List<TicketStatsDto> getStatsByMonth() {
+        return ticketRepository.countTicketsByMonth().stream()
+                .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
+                .toList();
     }
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -26,6 +26,7 @@ import com.compulandia.sistematickets.enums.TypeTicket;
 import com.compulandia.sistematickets.repository.TecnicoRepository;
 import com.compulandia.sistematickets.repository.TicketRepository;
 import com.compulandia.sistematickets.services.TicketService;
+import com.compulandia.sistematickets.dto.TicketStatsDto;
 
 import jakarta.annotation.PostConstruct;
 
@@ -79,6 +80,21 @@ public class TicketController {
     @PutMapping("/tickets/{ticketId}/actualizarTicket")
     public Ticket actualizarStatusDeTicket(@RequestParam TicketStatus status, @PathVariable Long ticketId){
         return ticketService.actualizaTicketPorStatus(status, ticketId);
+    }
+
+    @GetMapping("/ticketStats/day")
+    public List<TicketStatsDto> ticketStatsByDay(){
+        return ticketService.getStatsByDay();
+    }
+
+    @GetMapping("/ticketStats/week")
+    public List<TicketStatsDto> ticketStatsByWeek(){
+        return ticketService.getStatsByWeek();
+    }
+
+    @GetMapping("/ticketStats/month")
+    public List<TicketStatsDto> ticketStatsByMonth(){
+        return ticketService.getStatsByMonth();
     }
 @PostMapping(path = "/tickets", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Ticket guardarTicket(

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
@@ -1,0 +1,8 @@
+.chart-wrapper {
+  margin-bottom: 2rem;
+  height: 300px;
+}
+canvas {
+  width: 100% !important;
+  height: 100% !important;
+}

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
@@ -8,7 +8,18 @@
 
         <mat-divider></mat-divider>
         <mat-card-content>
-            Dashboard
+            <div class="chart-wrapper">
+                <h3>Tickets por día</h3>
+                <canvas id="dayChart"></canvas>
+            </div>
+            <div class="chart-wrapper">
+                <h3>Tickets por semana</h3>
+                <canvas id="weekChart"></canvas>
+            </div>
+            <div class="chart-wrapper">
+                <h3>Tickets por mes</h3>
+                <canvas id="monthChart"></canvas>
+            </div>
         </mat-card-content>
     </mat-card>
 </div>

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.ts
@@ -1,10 +1,42 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Chart } from 'chart.js/auto';
+import { DashboardService } from '../services/dashboard.service';
+import { TicketStat } from '../models/ticket-stat.model';
 
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']
 })
-export class DashboardComponent {
+export class DashboardComponent implements OnInit {
+  dayChart?: Chart;
+  weekChart?: Chart;
+  monthChart?: Chart;
 
+  constructor(private dashboardService: DashboardService) {}
+
+  ngOnInit(): void {
+    this.dashboardService.getStatsByDay().subscribe(d => this.createChart('dayChart', d));
+    this.dashboardService.getStatsByWeek().subscribe(d => this.createChart('weekChart', d));
+    this.dashboardService.getStatsByMonth().subscribe(d => this.createChart('monthChart', d));
+  }
+
+  private createChart(elementId: string, stats: TicketStat[]) {
+    const labels = stats.map(s => s.label);
+    const data = stats.map(s => s.count);
+    new Chart(elementId, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [{
+          data,
+          backgroundColor: '#2196F3'
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false
+      }
+    });
+  }
 }

--- a/sistema-tickets-frontend/src/app/models/ticket-stat.model.ts
+++ b/sistema-tickets-frontend/src/app/models/ticket-stat.model.ts
@@ -1,0 +1,4 @@
+export interface TicketStat {
+  label: string;
+  count: number;
+}

--- a/sistema-tickets-frontend/src/app/services/dashboard.service.ts
+++ b/sistema-tickets-frontend/src/app/services/dashboard.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment.development';
+import { TicketStat } from '../models/ticket-stat.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DashboardService {
+  constructor(private http: HttpClient) {}
+
+  getStatsByDay(): Observable<TicketStat[]> {
+    return this.http.get<TicketStat[]>(`${environment.backendHost}/ticketStats/day`);
+  }
+
+  getStatsByWeek(): Observable<TicketStat[]> {
+    return this.http.get<TicketStat[]>(`${environment.backendHost}/ticketStats/week`);
+  }
+
+  getStatsByMonth(): Observable<TicketStat[]> {
+    return this.http.get<TicketStat[]>(`${environment.backendHost}/ticketStats/month`);
+  }
+}


### PR DESCRIPTION
## Summary
- show ticket statistics from new backend endpoints
- render ticket stats per day, week and month in admin dashboard
- style dashboard charts

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6863779385c48323a707be2651128036