### PR TITLE
Add quotes creation to admin UI

### DIFF
--- a/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
+++ b/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
@@ -64,6 +64,13 @@
              </button>
 
         </mat-list-item>
+        <mat-list-item *ngIf="authService.roles.includes('ADMIN')">
+             <button mat-button routerLink="/admin/cotizaciones">
+                <mat-icon>description</mat-icon>
+                Cotizaciones
+             </button>
+
+        </mat-list-item>
     </mat-list>
     </mat-drawer>
     <mat-drawer-content>

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -17,6 +17,7 @@ import { NewTicketComponent } from './new-ticket/new-ticket.component';
 
 import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
 import { LoadServiciosComponent } from './load-servicios/load-servicios.component';
+import { QuotesComponent } from './quotes/quotes.component';
 const routes: Routes = [
   { path: "", component: LoginComponent },
   { path: "login", component: LoginComponent },
@@ -88,6 +89,12 @@ const routes: Routes = [
       {
         path: "new-ticket",
         component: NewTicketComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "cotizaciones",
+        component: QuotesComponent,
         canActivate: [AuthorizationGuard],
         data: { roles: ["ADMIN"] }
       }

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -22,7 +22,7 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { AuthGuard } from './guards/auth.guard';
 import { AuthorizationGuard } from './guards/authorization.guard';
 import { MatTableModule } from '@angular/material/table';
@@ -37,6 +37,7 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
 import { LoadServiciosComponent } from './load-servicios/load-servicios.component';
+import { QuotesComponent } from './quotes/quotes.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -53,12 +54,13 @@ import { LoadServiciosComponent } from './load-servicios/load-servicios.componen
     NewTicketComponent,
     TecnicoDashboardComponent,
     LoadServiciosComponent,
+    QuotesComponent,
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
     MatToolbarModule, MatButtonModule, MatIconModule, MatMenuModule, MatSidenavModule, MatListModule,
-    MatCardModule, MatFormFieldModule, MatInputModule, ReactiveFormsModule, MatTableModule,
+    MatCardModule, MatFormFieldModule, MatInputModule, ReactiveFormsModule, FormsModule, MatTableModule,
     HttpClientModule, MatPaginatorModule, MatSortModule, MatProgressSpinnerModule,
     MatDatepickerModule, MatNativeDateModule, MatSelectModule, BrowserModule
   ],

--- a/sistema-tickets-frontend/src/app/quotes/quotes.component.css
+++ b/sistema-tickets-frontend/src/app/quotes/quotes.component.css
@@ -1,0 +1,20 @@
+mat-form-field {
+  margin-right: 8px;
+}
+
+.item-form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+table {
+  width: 100%;
+  margin-bottom: 16px;
+}
+
+.total {
+  margin-bottom: 16px;
+}

--- a/sistema-tickets-frontend/src/app/quotes/quotes.component.html
+++ b/sistema-tickets-frontend/src/app/quotes/quotes.component.html
@@ -1,0 +1,56 @@
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Nueva Cotización</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <mat-form-field appearance="fill" style="width:100%;">
+      <mat-label>Cliente</mat-label>
+      <input matInput [(ngModel)]="cliente" />
+    </mat-form-field>
+
+    <div class="item-form">
+      <mat-form-field appearance="fill">
+        <mat-label>Descripción</mat-label>
+        <input matInput [(ngModel)]="newItem.description" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Cantidad</mat-label>
+        <input matInput type="number" [(ngModel)]="newItem.quantity" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Precio</mat-label>
+        <input matInput type="number" [(ngModel)]="newItem.price" />
+      </mat-form-field>
+      <button mat-raised-button color="primary" (click)="addItem()">Agregar</button>
+    </div>
+
+    <table class="table" *ngIf="items.length">
+      <thead>
+        <tr>
+          <th>Descripción</th>
+          <th>Cantidad</th>
+          <th>Precio</th>
+          <th>Total</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let item of items; let i=index">
+          <td>{{item.description}}</td>
+          <td>{{item.quantity}}</td>
+          <td>{{item.price}}</td>
+          <td>{{item.quantity * item.price}}</td>
+          <td>
+            <button mat-button color="warn" (click)="removeItem(i)">Eliminar</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="total" *ngIf="items.length">
+      <strong>Total: {{ total() }}</strong>
+    </div>
+
+    <button mat-raised-button color="accent" (click)="exportPDF()" [disabled]="!items.length">Exportar PDF</button>
+  </mat-card-content>
+</mat-card>

--- a/sistema-tickets-frontend/src/app/quotes/quotes.component.ts
+++ b/sistema-tickets-frontend/src/app/quotes/quotes.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+
+declare const jspdf: any;
+
+interface QuoteItem {
+  description: string;
+  quantity: number;
+  price: number;
+}
+
+@Component({
+  selector: 'app-quotes',
+  templateUrl: './quotes.component.html',
+  styleUrls: ['./quotes.component.css']
+})
+export class QuotesComponent {
+  cliente = '';
+  items: QuoteItem[] = [];
+  newItem: QuoteItem = { description: '', quantity: 1, price: 0 };
+
+  addItem() {
+    if (this.newItem.description) {
+      this.items.push({ ...this.newItem });
+      this.newItem = { description: '', quantity: 1, price: 0 };
+    }
+  }
+
+  removeItem(index: number) {
+    this.items.splice(index, 1);
+  }
+
+  total(): number {
+    return this.items.reduce((sum, item) => sum + item.quantity * item.price, 0);
+  }
+
+  exportPDF() {
+    const { jsPDF } = jspdf;
+    const doc = new jsPDF();
+    doc.text(`Cliente: ${this.cliente}`, 10, 10);
+    let y = 20;
+    this.items.forEach(item => {
+      doc.text(`${item.description} - ${item.quantity} x $${item.price}`, 10, y);
+      y += 10;
+    });
+    doc.text(`Total: $${this.total()}`, 10, y + 10);
+    doc.save('cotizacion.pdf');
+  }
+}

--- a/sistema-tickets-frontend/src/index.html
+++ b/sistema-tickets-frontend/src/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-XzCqETh1YWhv4jArlTcidH8333Adxpv8uKXuX4nHCqB6f+GO6zkRgZNpmjDoE7YQDdyCjTiMQuuLHcEGo1vYAw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 <body class="mat-typography">
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- add QuotesComponent for creating quotes and exporting to PDF
- expose new `cotizaciones` route in `app-routing`
- register QuotesComponent in `AppModule`
- add admin navigation link
- include jsPDF via CDN

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_686377b59e2083238fc994135ce39a2e