### PR TITLE
Restore quotes menu item

### DIFF
--- a/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
+++ b/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
@@ -73,7 +73,10 @@
              </button>
         </mat-list-item>
         <mat-list-item *ngIf="authService.roles.includes('ADMIN')">
-
+             <button mat-button routerLink="/admin/cotizaciones">
+                <mat-icon>description</mat-icon>
+                Cotizaciones
+             </button>
         </mat-list-item>
     </mat-list>
     </mat-drawer>


### PR DESCRIPTION
## Summary
- restore the Cotizaciones menu item in Admin Template

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6865f8f7a8508323b44da8457b53ee21