### PR TITLE
Fix jsPDF integrity hash

### DIFF
--- a/sistema-tickets-frontend/src/index.html
+++ b/sistema-tickets-frontend/src/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-XzCqETh1YWhv4jArlTcidH8333Adxpv8uKXuX4nHCqB6f+GO6zkRgZNpmjDoE7YQDdyCjTiMQuuLHcEGo1vYAw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-qZvrmS2ekKPF2mSznTQsxqPgnpkI4DNTlrdUmTzrDgektczlKNRRhy5X5AAOnx5S09ydFYWWNSfcEqDTTHgtNA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 <body class="mat-typography">
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- correct SRI hash for jsPDF in `index.html`

## Testing
- `node node_modules/@angular/cli/bin/ng test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68660985e89883239cdffc68b0618044