### PR TITLE
Enable client list in quotes form

### DIFF
--- a/sistema-tickets-frontend/src/app/quotes/quotes.component.html
+++ b/sistema-tickets-frontend/src/app/quotes/quotes.component.html
@@ -5,7 +5,11 @@
   <mat-card-content>
     <mat-form-field appearance="fill" style="width:100%;">
       <mat-label>Cliente</mat-label>
-      <input matInput [(ngModel)]="cliente" />
+      <mat-select [(ngModel)]="cliente">
+        <mat-option *ngFor="let c of clientes" [value]="c.nombre + ' ' + c.apellido">
+          {{ c.nombre }} {{ c.apellido }}
+        </mat-option>
+      </mat-select>
     </mat-form-field>
 
     <div class="item-form">

--- a/sistema-tickets-frontend/src/app/quotes/quotes.component.ts
+++ b/sistema-tickets-frontend/src/app/quotes/quotes.component.ts
@@ -1,10 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { TecnicosService } from '../services/tecnicos.service';
 import { MatCard } from '@angular/material/card';
+import { Cliente } from '../models/cliente.model';
+import { ClientesService } from '../services/clientes.service';
 
 declare const jspdf: any;
 
@@ -19,10 +21,20 @@ interface QuoteItem {
   templateUrl: './quotes.component.html',
   styleUrls: ['./quotes.component.css']
 })
-export class QuotesComponent {
+export class QuotesComponent implements OnInit {
   cliente = '';
+  clientes: Cliente[] = [];
   items: QuoteItem[] = [];
   newItem: QuoteItem = { description: '', quantity: 1, price: 0 };
+
+  constructor(private clientesService: ClientesService) {}
+
+  ngOnInit(): void {
+    this.clientesService.getClientes().subscribe({
+      next: clientes => (this.clientes = clientes),
+      error: err => console.error('Error al cargar clientes', err)
+    });
+  }
 
   addItem() {
     if (this.newItem.description) {


### PR DESCRIPTION
## Summary
- show saved clients in quotes page

## Testing
- `npm run build` *(fails: ng command not found)*
- `npm test` *(fails: ng command not found)*
- `./mvnw -q test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68660d98126483238d63d1f365dd0cd2