### PR TITLE
Add user profile section

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/AuthController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/AuthController.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +34,14 @@ public class AuthController {
             return ResponseEntity.ok(usuario);
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+
+    @GetMapping("/profile/{username}")
+    public ResponseEntity<Usuario> getProfile(@PathVariable String username) {
+        Usuario usuario = usuarioRepository.findByUsername(username);
+        if (usuario != null) {
+            return ResponseEntity.ok(usuario);
+        }
+        return ResponseEntity.notFound().build();
     }
 }

--- a/sistema-tickets-frontend/README.md
+++ b/sistema-tickets-frontend/README.md
@@ -14,6 +14,10 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
 
+## User Profile
+
+Navigate to `/admin/profile` after logging in as an administrator to view the logged user's information. This page shows the username, role and, if available, the technician code associated with the account.
+
 ## Running unit tests
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).

--- a/sistema-tickets-frontend/src/app/profile/profile.component.css
+++ b/sistema-tickets-frontend/src/app/profile/profile.component.css
@@ -1,0 +1,13 @@
+
+.profile-container {
+  max-width: 400px;
+  margin: 20px auto;
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.profile-container h2 {
+  margin-top: 0;
+}

--- a/sistema-tickets-frontend/src/app/profile/profile.component.html
+++ b/sistema-tickets-frontend/src/app/profile/profile.component.html
@@ -1,1 +1,6 @@
-<p>profile works!</p>
+<div class="profile-container" *ngIf="usuario">
+  <h2>Perfil de Usuario</h2>
+  <p><strong>Usuario:</strong> {{ usuario.username }}</p>
+  <p><strong>Rol:</strong> {{ usuario.role }}</p>
+  <p *ngIf="usuario.codigoTecnico"><strong>Código Técnico:</strong> {{ usuario.codigoTecnico }}</p>
+</div>

--- a/sistema-tickets-frontend/src/app/profile/profile.component.ts
+++ b/sistema-tickets-frontend/src/app/profile/profile.component.ts
@@ -1,10 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { Usuario } from '../models/usuario.model';
+import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.component.html',
   styleUrls: ['./profile.component.css']
 })
-export class ProfileComponent {
+export class ProfileComponent implements OnInit {
 
+  usuario?: Usuario;
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit(): void {
+    const username = this.authService.username;
+    if (username) {
+      this.authService.getProfile(username).subscribe(u => this.usuario = u);
+    }
+  }
 }

--- a/sistema-tickets-frontend/src/app/services/auth.service.ts
+++ b/sistema-tickets-frontend/src/app/services/auth.service.ts
@@ -52,6 +52,10 @@ public roles: string[] = [];
       );
   }
 
+  public getProfile(username: string): Observable<Usuario> {
+    return this.http.get<Usuario>(`${environment.backendHost}/api/auth/profile/${username}`);
+  }
+
   public register(usuario: Usuario): Observable<Usuario> {
     return this.http.post<Usuario>(`${environment.backendHost}/api/auth/register`, usuario);
   }


### PR DESCRIPTION
## Summary
- expose `/api/auth/profile/{username}` endpoint for user info
- retrieve user profile from frontend and display it
- style the profile page with a simple card
- document how to access the profile page

## Testing
- `npx ng test --watch=false` *(fails: ng permission denied)*
- `mvn -q test` *(fails: mvn command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660de11cc88323a30c5e3ddd2af37d