### PR TITLE
Add greeting component

### DIFF
--- a/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
+++ b/sistema-tickets-frontend/src/app/admin-template/admin-template.component.html
@@ -81,6 +81,7 @@
     </mat-list>
     </mat-drawer>
     <mat-drawer-content>
+        <app-greeting></app-greeting>
         <div class="div" style="min-height: 600px;">
             <router-outlet></router-outlet>
         </div>

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -40,6 +40,7 @@ import { LoadServiciosComponent } from './load-servicios/load-servicios.componen
 import { LoadClientesComponent } from './load-clientes/load-clientes.component';
 import { ClientesComponent } from './clientes/clientes.component';
 import { QuotesComponent } from './quotes/quotes.component';
+import { GreetingComponent } from './greeting/greeting.component';
 
 @NgModule({
   declarations: [
@@ -60,6 +61,7 @@ import { QuotesComponent } from './quotes/quotes.component';
     LoadClientesComponent,
     ClientesComponent,
     QuotesComponent,
+    GreetingComponent,
 
   ],
   imports: [

--- a/sistema-tickets-frontend/src/app/greeting/greeting.component.css
+++ b/sistema-tickets-frontend/src/app/greeting/greeting.component.css
@@ -1,0 +1,4 @@
+.greeting {
+  margin: 16px;
+  font-size: 1.2em;
+}

--- a/sistema-tickets-frontend/src/app/greeting/greeting.component.html
+++ b/sistema-tickets-frontend/src/app/greeting/greeting.component.html
@@ -1,0 +1,3 @@
+<div class="greeting" *ngIf="authService.isAuthenticated">
+  ¡Hola, {{ authService.username }}!
+</div>

--- a/sistema-tickets-frontend/src/app/greeting/greeting.component.ts
+++ b/sistema-tickets-frontend/src/app/greeting/greeting.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+@Component({
+  selector: 'app-greeting',
+  templateUrl: './greeting.component.html',
+  styleUrls: ['./greeting.component.css']
+})
+export class GreetingComponent {
+  constructor(public authService: AuthService) {}
+}


### PR DESCRIPTION
## Summary
- show greeting for authenticated user in admin template
- declare new GreetingComponent

## Testing
- `npm test --silent` *(fails: ng Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68660dfeab8083238100a9cec7532392