### PR TITLE
Add full client info table

### DIFF
--- a/sistema-tickets-frontend/src/app/clientes/clientes.component.html
+++ b/sistema-tickets-frontend/src/app/clientes/clientes.component.html
@@ -12,6 +12,26 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Apellido</th>
       <td mat-cell *matCellDef="let element">{{ element.apellido }}</td>
     </ng-container>
+    <ng-container matColumnDef="email">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Email</th>
+      <td mat-cell *matCellDef="let element">{{ element.email }}</td>
+    </ng-container>
+    <ng-container matColumnDef="telefono">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Teléfono</th>
+      <td mat-cell *matCellDef="let element">{{ element.telefono }}</td>
+    </ng-container>
+    <ng-container matColumnDef="direccion">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Dirección</th>
+      <td mat-cell *matCellDef="let element">{{ element.direccion }}</td>
+    </ng-container>
+    <ng-container matColumnDef="ciudad">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Ciudad</th>
+      <td mat-cell *matCellDef="let element">{{ element.ciudad }}</td>
+    </ng-container>
+    <ng-container matColumnDef="codigoPostal">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>Código Postal</th>
+      <td mat-cell *matCellDef="let element">{{ element.codigoPostal }}</td>
+    </ng-container>
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
   </table>

--- a/sistema-tickets-frontend/src/app/clientes/clientes.component.ts
+++ b/sistema-tickets-frontend/src/app/clientes/clientes.component.ts
@@ -14,7 +14,16 @@ export class ClientesComponent implements OnInit {
 
   clientes: Cliente[] = [];
   dataSource!: MatTableDataSource<Cliente>;
-  displayedColumns: string[] = ['id', 'nombre', 'apellido'];
+  displayedColumns: string[] = [
+    'id',
+    'nombre',
+    'apellido',
+    'email',
+    'telefono',
+    'direccion',
+    'ciudad',
+    'codigoPostal'
+  ];
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;


### PR DESCRIPTION
## Summary
- extend ClientesComponent to include full client properties
- display email, phone, address, city and postal code in the clientes table

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686615d24f20832381d14f785ec591e3