### PR TITLE
Improve admin dashboard metrics

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
@@ -27,4 +27,13 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     @Query(value = "SELECT DATE_FORMAT(fecha, '%Y-%m') as label, COUNT(*) as count FROM ticket GROUP BY DATE_FORMAT(fecha, '%Y-%m') ORDER BY DATE_FORMAT(fecha, '%Y-%m')", nativeQuery = true)
     List<Object[]> countTicketsByMonth();
 
+    @Query(value = "SELECT s.nombre as label, COUNT(*) as count FROM ticket t JOIN servicio s ON t.servicio_id = s.id GROUP BY s.nombre ORDER BY count DESC LIMIT 5", nativeQuery = true)
+    List<Object[]> topServicios();
+
+    @Query(value = "SELECT CONCAT(c.nombre, ' ', c.apellido) as label, COUNT(*) as count FROM ticket t JOIN cliente c ON t.cliente_id = c.id GROUP BY c.id, c.nombre, c.apellido ORDER BY count DESC LIMIT 5", nativeQuery = true)
+    List<Object[]> topClientes();
+
+    @Query(value = "SELECT te.codigo as label, COUNT(*) as count FROM ticket t JOIN tecnico te ON t.tecnico_id = te.id GROUP BY te.codigo ORDER BY count DESC LIMIT 5", nativeQuery = true)
+    List<Object[]> topTecnicos();
+
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -176,4 +176,22 @@ public class TicketService {
                 .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
                 .toList();
     }
+
+    public List<TicketStatsDto> getTopServicios() {
+        return ticketRepository.topServicios().stream()
+                .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
+                .toList();
+    }
+
+    public List<TicketStatsDto> getTopClientes() {
+        return ticketRepository.topClientes().stream()
+                .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
+                .toList();
+    }
+
+    public List<TicketStatsDto> getTopTecnicos() {
+        return ticketRepository.topTecnicos().stream()
+                .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
+                .toList();
+    }
 }

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -96,6 +96,21 @@ public class TicketController {
     public List<TicketStatsDto> ticketStatsByMonth(){
         return ticketService.getStatsByMonth();
     }
+
+    @GetMapping("/ticketStats/servicios")
+    public List<TicketStatsDto> topServicios(){
+        return ticketService.getTopServicios();
+    }
+
+    @GetMapping("/ticketStats/clientes")
+    public List<TicketStatsDto> topClientes(){
+        return ticketService.getTopClientes();
+    }
+
+    @GetMapping("/ticketStats/tecnicos")
+    public List<TicketStatsDto> topTecnicos(){
+        return ticketService.getTopTecnicos();
+    }
 @PostMapping(path = "/tickets", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Ticket guardarTicket(
         @RequestParam(value="file", required=false) MultipartFile file,

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
@@ -20,6 +20,18 @@
                 <h3>Tickets por mes</h3>
                 <canvas id="monthChart"></canvas>
             </div>
+            <div class="chart-wrapper">
+                <h3>Servicios más demandados</h3>
+                <canvas id="serviciosChart"></canvas>
+            </div>
+            <div class="chart-wrapper">
+                <h3>Clientes frecuentes</h3>
+                <canvas id="clientesChart"></canvas>
+            </div>
+            <div class="chart-wrapper">
+                <h3>Técnicos más destacados</h3>
+                <canvas id="tecnicosChart"></canvas>
+            </div>
         </mat-card-content>
     </mat-card>
 </div>

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.ts
@@ -12,6 +12,9 @@ export class DashboardComponent implements OnInit {
   dayChart?: Chart;
   weekChart?: Chart;
   monthChart?: Chart;
+  serviciosChart?: Chart;
+  clientesChart?: Chart;
+  tecnicosChart?: Chart;
 
   constructor(private dashboardService: DashboardService) {}
 
@@ -19,6 +22,9 @@ export class DashboardComponent implements OnInit {
     this.dashboardService.getStatsByDay().subscribe(d => this.createChart('dayChart', d));
     this.dashboardService.getStatsByWeek().subscribe(d => this.createChart('weekChart', d));
     this.dashboardService.getStatsByMonth().subscribe(d => this.createChart('monthChart', d));
+    this.dashboardService.getTopServicios().subscribe(d => this.createChart('serviciosChart', d));
+    this.dashboardService.getTopClientes().subscribe(d => this.createChart('clientesChart', d));
+    this.dashboardService.getTopTecnicos().subscribe(d => this.createChart('tecnicosChart', d));
   }
 
   private createChart(elementId: string, stats: TicketStat[]) {

--- a/sistema-tickets-frontend/src/app/services/dashboard.service.ts
+++ b/sistema-tickets-frontend/src/app/services/dashboard.service.ts
@@ -21,4 +21,16 @@ export class DashboardService {
   getStatsByMonth(): Observable<TicketStat[]> {
     return this.http.get<TicketStat[]>(`${environment.backendHost}/ticketStats/month`);
   }
+
+  getTopServicios(): Observable<TicketStat[]> {
+    return this.http.get<TicketStat[]>(`${environment.backendHost}/ticketStats/servicios`);
+  }
+
+  getTopClientes(): Observable<TicketStat[]> {
+    return this.http.get<TicketStat[]>(`${environment.backendHost}/ticketStats/clientes`);
+  }
+
+  getTopTecnicos(): Observable<TicketStat[]> {
+    return this.http.get<TicketStat[]>(`${environment.backendHost}/ticketStats/tecnicos`);
+  }
 }


### PR DESCRIPTION
## Summary
- add repository queries for most popular services, top clients and technicians
- expose dashboard endpoints for new stats
- show additional charts on the admin dashboard
- extend dashboard service and component

## Testing
- `node node_modules/@angular/cli/bin/ng test --watch=false` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `./mvnw -q test` *(fails: could not resolve Spring artifacts due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686616e664688323aad544b8d0a4a0f1