### PR TITLE
Fix chart layout in admin dashboard

### DIFF
--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
@@ -1,7 +1,16 @@
 .chart-wrapper {
   margin-bottom: 2rem;
-  height: 300px;
+  height: 250px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
+
+.chart-wrapper h3 {
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
 canvas {
   width: 100% !important;
   height: 100% !important;


### PR DESCRIPTION
## Summary
- adjust chart wrapper height and center titles

## Testing
- `node node_modules/@angular/cli/bin/ng test --watch=false` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661dc61bfc8323972ebd79c1c544bd