### PR TITLE
Improve dashboard chart layout

### DIFF
--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
@@ -1,17 +1,31 @@
-.chart-wrapper {
-  margin-bottom: 2rem;
-  height: 250px;
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.chart-card {
+  height: 240px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
 }
 
-.chart-wrapper h3 {
-  margin-bottom: 0.5rem;
+.chart-card mat-card-title {
+  font-size: 1rem;
+  font-weight: 600;
   text-align: center;
+  margin-bottom: 0.25rem;
 }
 
-canvas {
+.chart-card canvas {
   width: 100% !important;
-  height: 100% !important;
+  height: 180px !important;
+}
+
+.dashboard-title {
+  margin-bottom: 1rem;
+  font-size: 1.4rem;
+  text-align: center;
 }

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
@@ -1,37 +1,58 @@
 <div class="container">
-    <mat-card>
-        <mat-card-header>
-            <mat-card-title>
-                Dashboard
-            </mat-card-title>
-        </mat-card-header>
-
-        <mat-divider></mat-divider>
-        <mat-card-content>
-            <div class="chart-wrapper">
-                <h3>Tickets por día</h3>
-                <canvas id="dayChart"></canvas>
-            </div>
-            <div class="chart-wrapper">
-                <h3>Tickets por semana</h3>
-                <canvas id="weekChart"></canvas>
-            </div>
-            <div class="chart-wrapper">
-                <h3>Tickets por mes</h3>
-                <canvas id="monthChart"></canvas>
-            </div>
-            <div class="chart-wrapper">
-                <h3>Servicios más demandados</h3>
-                <canvas id="serviciosChart"></canvas>
-            </div>
-            <div class="chart-wrapper">
-                <h3>Clientes frecuentes</h3>
-                <canvas id="clientesChart"></canvas>
-            </div>
-            <div class="chart-wrapper">
-                <h3>Técnicos más destacados</h3>
-                <canvas id="tecnicosChart"></canvas>
-            </div>
-        </mat-card-content>
+  <h2 class="dashboard-title">Dashboard</h2>
+  <div class="charts-grid">
+    <mat-card class="chart-card">
+      <mat-card-header>
+        <mat-card-title>Tickets por día</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <canvas id="dayChart"></canvas>
+      </mat-card-content>
     </mat-card>
+
+    <mat-card class="chart-card">
+      <mat-card-header>
+        <mat-card-title>Tickets por semana</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <canvas id="weekChart"></canvas>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card class="chart-card">
+      <mat-card-header>
+        <mat-card-title>Tickets por mes</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <canvas id="monthChart"></canvas>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card class="chart-card">
+      <mat-card-header>
+        <mat-card-title>Servicios más demandados</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <canvas id="serviciosChart"></canvas>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card class="chart-card">
+      <mat-card-header>
+        <mat-card-title>Clientes frecuentes</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <canvas id="clientesChart"></canvas>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card class="chart-card">
+      <mat-card-header>
+        <mat-card-title>Técnicos más destacados</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <canvas id="tecnicosChart"></canvas>
+      </mat-card-content>
+    </mat-card>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- style dashboard charts in smaller material cards
- lay out the grid so multiple graphs show at once

## Testing
- `npm install`
- `node ./node_modules/@angular/cli/bin/ng build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*


------
https://chatgpt.com/codex/tasks/task_e_6868057048bc832395fd3b82501703f4