### PR TITLE
Implement hover and click scale for charts

### DIFF
--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.css
@@ -22,6 +22,14 @@
 .chart-card canvas {
   width: 100% !important;
   height: 180px !important;
+  transition: transform 0.3s ease;
+  cursor: pointer;
+}
+
+.chart-card canvas:hover,
+.chart-card canvas:active {
+  transform: scale(1.1);
+  z-index: 1;
 }
 
 .dashboard-title {

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
@@ -74,3 +74,16 @@ h3 {
   margin: 1rem auto;
   height: 300px;
 }
+
+.chart-container canvas {
+  width: 100% !important;
+  height: 100% !important;
+  transition: transform 0.3s ease;
+  cursor: pointer;
+}
+
+.chart-container canvas:hover,
+.chart-container canvas:active {
+  transform: scale(1.1);
+  z-index: 1;
+}


### PR DESCRIPTION
## Summary
- make dashboard charts scale when hovered or clicked
- make technician dashboard chart scale on hover or click

## Testing
- `npx ng test --watch=false` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_686807bb2a2083238da796f31a0e5a1a