### PR TITLE
Add ticket history tracking

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
@@ -36,6 +36,9 @@ public class Ticket {
 
     private TicketStatus status;
 
+    @Builder.Default
+    private boolean deleted = false;
+
     private String file;
 
     // Campos adicionales para cada tipo de servicio

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/TicketHistory.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/TicketHistory.java
@@ -1,0 +1,41 @@
+package com.compulandia.sistematickets.entities;
+
+import java.time.LocalDateTime;
+
+import com.compulandia.sistematickets.enums.TicketStatus;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TicketHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Ticket ticket;
+
+    private String action;
+
+    @Enumerated(EnumType.STRING)
+    private TicketStatus previousStatus;
+
+    @Enumerated(EnumType.STRING)
+    private TicketStatus newStatus;
+
+    private LocalDateTime timestamp;
+}

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketHistoryRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.compulandia.sistematickets.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.compulandia.sistematickets.entities.TicketHistory;
+
+public interface TicketHistoryRepository extends JpaRepository<TicketHistory, Long> {
+    List<TicketHistory> findByTicketIdOrderByTimestampAsc(Long ticketId);
+}

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
@@ -12,11 +12,13 @@ import com.compulandia.sistematickets.enums.TypeTicket;
 
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
-    List<Ticket> findByTecnicoCodigo(String codigo);
+    List<Ticket> findByTecnicoCodigoAndDeletedFalse(String codigo);
 
-    List<Ticket> findByStatus(TicketStatus status);
+    List<Ticket> findByStatusAndDeletedFalse(TicketStatus status);
 
-    List<Ticket> findByType(TypeTicket typeTicket);
+    List<Ticket> findByTypeAndDeletedFalse(TypeTicket typeTicket);
+
+    List<Ticket> findByDeletedFalse();
 
     @Query(value = "SELECT fecha as label, COUNT(*) as count FROM ticket GROUP BY fecha ORDER BY fecha", nativeQuery = true)
     List<Object[]> countTicketsByDay();

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -16,12 +16,14 @@ import org.springframework.web.multipart.MultipartFile;
 import com.compulandia.sistematickets.entities.Tecnico;
 import com.compulandia.sistematickets.entities.Ticket;
 import com.compulandia.sistematickets.entities.Servicio;
+import com.compulandia.sistematickets.entities.TicketHistory;
 import com.compulandia.sistematickets.dto.TicketStatsDto;
 import com.compulandia.sistematickets.entities.Cliente;
 import com.compulandia.sistematickets.enums.TicketStatus;
 import com.compulandia.sistematickets.enums.TypeTicket;
 import com.compulandia.sistematickets.repository.TecnicoRepository;
 import com.compulandia.sistematickets.repository.TicketRepository;
+import com.compulandia.sistematickets.repository.TicketHistoryRepository;
 import com.compulandia.sistematickets.repository.ClienteRepository;
 import com.compulandia.sistematickets.repository.ServicioRepository;
 
@@ -42,6 +44,19 @@ public class TicketService {
 
     @Autowired
     private ClienteRepository clienteRepository;
+
+    @Autowired
+    private TicketHistoryRepository historyRepository;
+
+    private void saveHistory(Ticket ticket, String action, TicketStatus previous, TicketStatus current) {
+        historyRepository.save(TicketHistory.builder()
+                .ticket(ticket)
+                .action(action)
+                .previousStatus(previous)
+                .newStatus(current)
+                .timestamp(java.time.LocalDateTime.now())
+                .build());
+    }
 
     public Ticket saveTicket(MultipartFile file, String tecnicoCodigo, double cantidad, String servicioNombre, LocalDate date,
             Long clienteId,
@@ -135,7 +150,9 @@ public class TicketService {
                 .diagnosticoObservaciones(diagnosticoObservaciones)
                 .build();
 
-        return ticketRepository.save(ticket);
+        Ticket saved = ticketRepository.save(ticket);
+        saveHistory(saved, "CREATED", null, saved.getStatus());
+        return saved;
 
     }
 
@@ -160,6 +177,7 @@ public class TicketService {
             String diagnosticoObservaciones) throws IOException {
 
         Ticket ticket = ticketRepository.findById(id).orElseThrow();
+        TicketStatus previousStatus = ticket.getStatus();
 
         Path filePath = null;
         if (file != null && !file.isEmpty()) {
@@ -219,7 +237,9 @@ public class TicketService {
         ticket.setDiagnosticoProblema(diagnosticoProblema);
         ticket.setDiagnosticoObservaciones(diagnosticoObservaciones);
 
-        return ticketRepository.save(ticket);
+        Ticket saved = ticketRepository.save(ticket);
+        saveHistory(saved, "UPDATED", previousStatus, saved.getStatus());
+        return saved;
     }
     public byte[] getArchivoPorId(Long ticketId) throws IOException{
         Ticket ticket = ticketRepository.findById(ticketId).get();
@@ -238,8 +258,35 @@ public class TicketService {
     }
     public Ticket actualizaTicketPorStatus(TicketStatus status, long id){
         Ticket ticket = ticketRepository.findById(id).get();
+        TicketStatus previous = ticket.getStatus();
         ticket.setStatus(status);
-        return ticketRepository.save(ticket);
+        Ticket saved = ticketRepository.save(ticket);
+        saveHistory(saved, "STATUS_CHANGED", previous, saved.getStatus());
+        return saved;
+    }
+
+    public void deleteTicket(Long id) {
+        Ticket ticket = ticketRepository.findById(id).orElseThrow();
+        if (!ticket.isDeleted()) {
+            ticket.setDeleted(true);
+            Ticket saved = ticketRepository.save(ticket);
+            saveHistory(saved, "DELETED", saved.getStatus(), saved.getStatus());
+        }
+    }
+
+    public Ticket restoreTicket(Long id) {
+        Ticket ticket = ticketRepository.findById(id).orElseThrow();
+        if (ticket.isDeleted()) {
+            ticket.setDeleted(false);
+            Ticket saved = ticketRepository.save(ticket);
+            saveHistory(saved, "RESTORED", saved.getStatus(), saved.getStatus());
+            return saved;
+        }
+        return ticket;
+    }
+
+    public List<TicketHistory> getHistory(Long ticketId) {
+        return historyRepository.findByTicketIdOrderByTimestampAsc(ticketId);
     }
 
     public List<TicketStatsDto> getStatsByDay() {

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,6 +22,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.compulandia.sistematickets.entities.Tecnico;
 import com.compulandia.sistematickets.entities.Ticket;
+import com.compulandia.sistematickets.entities.TicketHistory;
 import com.compulandia.sistematickets.enums.TicketStatus;
 import com.compulandia.sistematickets.enums.TypeTicket;
 import com.compulandia.sistematickets.repository.TecnicoRepository;
@@ -58,7 +60,7 @@ public class TicketController {
 
     @GetMapping("/tickets")
     public List<Ticket> listarTickets(){
-        return ticketRepository.findAll();
+        return ticketRepository.findByDeletedFalse();
     }
     @GetMapping("/tickets/{id}")
     public Ticket listarTicketPorId(@PathVariable Long id){
@@ -66,16 +68,16 @@ public class TicketController {
     }
     @GetMapping("/tecnicos/{codigo}/tickets")
     public List<Ticket> listarTicketsPorCodigoTecnico(@PathVariable String codigo){
-        return ticketRepository.findByTecnicoCodigo(codigo);
+        return ticketRepository.findByTecnicoCodigoAndDeletedFalse(codigo);
     }
     @GetMapping("/ticketsPorStatus")
     public List<Ticket> listarTicketsPorStatus(@RequestParam TicketStatus status){
-        return ticketRepository.findByStatus(status);
+        return ticketRepository.findByStatusAndDeletedFalse(status);
     }
     @GetMapping("/tickets/porTipo")
      public List<Ticket> listarTicketsPorType(@RequestParam TypeTicket type){
-        return ticketRepository.findByType(type);
-    }  
+        return ticketRepository.findByTypeAndDeletedFalse(type);
+    }
 
     @PutMapping("/tickets/{ticketId}/actualizarTicket")
     public Ticket actualizarStatusDeTicket(@RequestParam TicketStatus status, @PathVariable Long ticketId){
@@ -203,7 +205,21 @@ public class TicketController {
             diagnosticoObservaciones
         );
     }
-   
+
+    @DeleteMapping("/tickets/{ticketId}")
+    public void eliminarTicket(@PathVariable Long ticketId){
+        ticketService.deleteTicket(ticketId);
     }
+
+    @PutMapping("/tickets/{ticketId}/restore")
+    public Ticket restaurarTicket(@PathVariable Long ticketId){
+        return ticketService.restoreTicket(ticketId);
+    }
+
+    @GetMapping("/tickets/{ticketId}/history")
+    public List<TicketHistory> historialTicket(@PathVariable Long ticketId){
+        return ticketService.getHistory(ticketId);
+    }
+}
 
 

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -21,6 +21,7 @@ import { LoadServiciosComponent } from './load-servicios/load-servicios.componen
 import { LoadClientesComponent } from './load-clientes/load-clientes.component';
 import { ClientesComponent } from './clientes/clientes.component';
 import { QuotesComponent } from './quotes/quotes.component';
+import { TicketDetailsComponent } from './ticket-details/ticket-details.component';
 
 const routes: Routes = [
   { path: "", component: LoginComponent },
@@ -111,6 +112,12 @@ const routes: Routes = [
       {
         path: "edit-ticket/:id",
         component: EditTicketComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "ticket-details/:id",
+        component: TicketDetailsComponent,
         canActivate: [AuthorizationGuard],
         data: { roles: ["ADMIN"] }
       },

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { LoadClientesComponent } from './load-clientes/load-clientes.component';
 import { ClientesComponent } from './clientes/clientes.component';
 import { QuotesComponent } from './quotes/quotes.component';
 import { GreetingComponent } from './greeting/greeting.component';
+import { TicketDetailsComponent } from './ticket-details/ticket-details.component';
 
 @NgModule({
   declarations: [
@@ -64,6 +65,7 @@ import { GreetingComponent } from './greeting/greeting.component';
     ClientesComponent,
     QuotesComponent,
     GreetingComponent,
+    TicketDetailsComponent,
 
   ],
   imports: [

--- a/sistema-tickets-frontend/src/app/models/ticket-history.model.ts
+++ b/sistema-tickets-frontend/src/app/models/ticket-history.model.ts
@@ -1,0 +1,7 @@
+export interface TicketHistory {
+  id: number;
+  action: string;
+  previousStatus: string | null;
+  newStatus: string | null;
+  timestamp: string;
+}

--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -56,4 +56,16 @@ export class TecnicosService {
       }
     );
   }
+
+  public getTicketHistory(id: number): Observable<any[]> {
+    return this.http.get<any[]>(`${environment.backendHost}/tickets/${id}/history`);
+  }
+
+  public deleteTicket(id: number): Observable<void> {
+    return this.http.delete<void>(`${environment.backendHost}/tickets/${id}`);
+  }
+
+  public restoreTicket(id: number): Observable<Ticket> {
+    return this.http.put<Ticket>(`${environment.backendHost}/tickets/${id}/restore`, null);
+  }
 }

--- a/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.html
+++ b/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.html
@@ -1,0 +1,30 @@
+<div class="container">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Historial de Ticket</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="dataSource" class="mat-elevation-z1">
+        <ng-container matColumnDef="timestamp">
+          <th mat-header-cell *matHeaderCellDef>Fecha</th>
+          <td mat-cell *matCellDef="let h">{{h.timestamp}}</td>
+        </ng-container>
+        <ng-container matColumnDef="action">
+          <th mat-header-cell *matHeaderCellDef>Acción</th>
+          <td mat-cell *matCellDef="let h">{{h.action}}</td>
+        </ng-container>
+        <ng-container matColumnDef="previousStatus">
+          <th mat-header-cell *matHeaderCellDef>Status Anterior</th>
+          <td mat-cell *matCellDef="let h">{{h.previousStatus}}</td>
+        </ng-container>
+        <ng-container matColumnDef="newStatus">
+          <th mat-header-cell *matHeaderCellDef>Status Nuevo</th>
+          <td mat-cell *matCellDef="let h">{{h.newStatus}}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+      <button mat-raised-button color="primary" (click)="restore()">Restaurar</button>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.ts
+++ b/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatTableDataSource } from '@angular/material/table';
+import { TecnicosService } from '../services/tecnicos.service';
+import { TicketHistory } from '../models/ticket-history.model';
+
+@Component({
+  selector: 'app-ticket-details',
+  templateUrl: './ticket-details.component.html',
+  styleUrls: ['./ticket-details.component.css']
+})
+export class TicketDetailsComponent implements OnInit {
+  histories: TicketHistory[] = [];
+  dataSource = new MatTableDataSource<TicketHistory>();
+  displayedColumns = ['timestamp','action','previousStatus','newStatus'];
+  ticketId!: number;
+
+  constructor(private route: ActivatedRoute, private service: TecnicosService){}
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      this.ticketId = +params['id'];
+      this.service.getTicketHistory(this.ticketId).subscribe(data => {
+        this.histories = data;
+        this.dataSource.data = this.histories;
+      });
+    });
+  }
+
+  restore(){
+    this.service.restoreTicket(this.ticketId).subscribe(()=>{
+      this.service.getTicketHistory(this.ticketId).subscribe(d=>this.dataSource.data=d);
+    });
+  }
+}

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.html
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.html
@@ -88,6 +88,9 @@
                         <button mat-icon-button color="primary" [routerLink]="['/admin/edit-ticket', element.id]">
                             <mat-icon>edit</mat-icon>
                         </button>
+                        <button mat-icon-button color="accent" (click)="verDetalles(element.id)">
+                            <mat-icon>info</mat-icon>
+                        </button>
                     </td>
                 </ng-container>
 

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.ts
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.ts
@@ -4,6 +4,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { TecnicosService } from '../services/tecnicos.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-tickets',
@@ -19,7 +20,7 @@ public tickets: any;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 
-  constructor(private http: HttpClient, private tecnicoService: TecnicosService) { }
+  constructor(private http: HttpClient, private tecnicoService: TecnicosService, private router: Router) { }
   ngOnInit(): void {
     this.tecnicoService.getAllTickets().subscribe({
       next: data => {
@@ -32,5 +33,9 @@ public tickets: any;
         console.error('Error al obtener los tickets', err);
       }
     })
+  }
+
+  verDetalles(id: number){
+    this.router.navigate(['/admin/ticket-details', id]);
   }
 }


### PR DESCRIPTION
## Summary
- add new `TicketHistory` entity and repository
- track ticket status and deletion changes
- expose history, delete, and restore endpoints
- add Angular ticket history component and routing
- update services and list view to link to history

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*
- `npm test` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68680a5366048323a4a345d486ae607a