### PR TITLE
Add service report on ticket finalization

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
@@ -8,6 +8,7 @@ import com.compulandia.sistematickets.entities.Servicio;
 import com.compulandia.sistematickets.entities.Cliente;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Column;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,6 +40,7 @@ public class Ticket {
     private String file;
 
     // Reporte realizado por el técnico al finalizar el servicio
+    @Column(columnDefinition = "TEXT")
     private String reporteServicio;
 
     // Campos adicionales para cada tipo de servicio

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Ticket.java
@@ -38,6 +38,9 @@ public class Ticket {
 
     private String file;
 
+    // Reporte realizado por el técnico al finalizar el servicio
+    private String reporteServicio;
+
     // Campos adicionales para cada tipo de servicio
     private String instalacionEquipo;
     private String instalacionModelo;

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -242,6 +242,13 @@ public class TicketService {
         return ticketRepository.save(ticket);
     }
 
+    public Ticket finalizarConReporte(Long id, String reporte){
+        Ticket ticket = ticketRepository.findById(id).orElseThrow();
+        ticket.setStatus(TicketStatus.FINALIZADO);
+        ticket.setReporteServicio(reporte);
+        return ticketRepository.save(ticket);
+    }
+
     public List<TicketStatsDto> getStatsByDay() {
         return ticketRepository.countTicketsByDay().stream()
                 .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/TicketController.java
@@ -82,6 +82,11 @@ public class TicketController {
         return ticketService.actualizaTicketPorStatus(status, ticketId);
     }
 
+    @PutMapping("/tickets/{ticketId}/finalizar")
+    public Ticket finalizarTicket(@PathVariable Long ticketId, @RequestParam String reporte){
+        return ticketService.finalizarConReporte(ticketId, reporte);
+    }
+
     @GetMapping("/ticketStats/day")
     public List<TicketStatsDto> ticketStatsByDay(){
         return ticketService.getStatsByDay();

--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -21,6 +21,7 @@ import { LoadServiciosComponent } from './load-servicios/load-servicios.componen
 import { LoadClientesComponent } from './load-clientes/load-clientes.component';
 import { ClientesComponent } from './clientes/clientes.component';
 import { QuotesComponent } from './quotes/quotes.component';
+import { TicketReportComponent } from './ticket-report/ticket-report.component';
 
 const routes: Routes = [
   { path: "", component: LoginComponent },
@@ -75,6 +76,12 @@ const routes: Routes = [
       {
         path: "dashboard-tecnico",
         component: TecnicoDashboardComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN", "TECNICO"] }
+      },
+      {
+        path: "ticket-report/:id",
+        component: TicketReportComponent,
         canActivate: [AuthorizationGuard],
         data: { roles: ["ADMIN", "TECNICO"] }
       },

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { LoadClientesComponent } from './load-clientes/load-clientes.component';
 import { ClientesComponent } from './clientes/clientes.component';
 import { QuotesComponent } from './quotes/quotes.component';
 import { GreetingComponent } from './greeting/greeting.component';
+import { TicketReportComponent } from './ticket-report/ticket-report.component';
 
 @NgModule({
   declarations: [
@@ -64,6 +65,7 @@ import { GreetingComponent } from './greeting/greeting.component';
     ClientesComponent,
     QuotesComponent,
     GreetingComponent,
+    TicketReportComponent,
 
   ],
   imports: [

--- a/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
+++ b/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
@@ -32,6 +32,7 @@ export interface Ticket {
     diagnosticoEquipo?: string;
     diagnosticoProblema?: string;
     diagnosticoObservaciones?: string;
+    reporteServicio?: string;
 }
 
 export enum TicketType {

--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -63,4 +63,14 @@ export class TecnicosService {
       }
     );
   }
+
+  public finalizarTicket(id: number, reporte: string): Observable<Ticket> {
+    return this.http.put<Ticket>(
+      `${environment.backendHost}/tickets/${id}/finalizar`,
+      null,
+      {
+        params: { reporte }
+      }
+    );
+  }
 }

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -4,6 +4,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { Ticket } from '../models/tecnicos.model';
 import { TecnicosService } from '../services/tecnicos.service';
 import { AuthService } from '../services/auth.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-tecnico-dashboard',
@@ -27,7 +28,7 @@ export class TecnicoDashboardComponent implements OnInit {
   activeCategory = '';
   statusChart?: Chart<any, any, any>;
 
-  constructor(private tecnicosService: TecnicosService, private authService: AuthService) {}
+  constructor(private tecnicosService: TecnicosService, private authService: AuthService, private router: Router) {}
 
   ngOnInit(): void {
     this.tecnicoCodigo = this.authService.codigoTecnico;
@@ -113,7 +114,7 @@ export class TecnicoDashboardComponent implements OnInit {
   }
 
   finalizarTicket(ticket: Ticket) {
-    this.actualizarEstado(ticket, 'FINALIZADO');
+    this.router.navigate(['/admin/ticket-report', ticket.id]);
   }
 
   cancelarTicket(ticket: Ticket) {

--- a/sistema-tickets-frontend/src/app/ticket-report/ticket-report.component.html
+++ b/sistema-tickets-frontend/src/app/ticket-report/ticket-report.component.html
@@ -1,0 +1,10 @@
+<div class="container">
+  <mat-card>
+    <mat-card-title>Reporte del servicio</mat-card-title>
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Escribe el reporte</mat-label>
+      <textarea matInput rows="5" [(ngModel)]="reporte"></textarea>
+    </mat-form-field>
+    <button mat-raised-button color="primary" (click)="guardar()">Guardar</button>
+  </mat-card>
+</div>

--- a/sistema-tickets-frontend/src/app/ticket-report/ticket-report.component.ts
+++ b/sistema-tickets-frontend/src/app/ticket-report/ticket-report.component.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TecnicosService } from '../services/tecnicos.service';
+import Swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-ticket-report',
+  templateUrl: './ticket-report.component.html',
+  styleUrls: ['./ticket-report.component.css']
+})
+export class TicketReportComponent {
+  reporte = '';
+  ticketId!: number;
+
+  constructor(private route: ActivatedRoute, private service: TecnicosService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.ticketId = +this.route.snapshot.paramMap.get('id')!;
+  }
+
+  guardar() {
+    this.service.finalizarTicket(this.ticketId, this.reporte).subscribe({
+      next: () => {
+        Swal.fire('Reporte guardado', 'El ticket fue finalizado', 'success').then(() => {
+          this.router.navigate(['/admin/dashboard-tecnico']);
+        });
+      },
+      error: () => {
+        Swal.fire('Error', 'No se pudo guardar el reporte', 'error');
+      }
+    });
+  }
+}

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.html
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.html
@@ -82,6 +82,11 @@
                     </td>
                 </ng-container>
 
+                <ng-container matColumnDef="reporte">
+                    <th mat-header-cell *matHeaderCellDef mat-sort-header>Reporte del servicio</th>
+                    <td mat-cell *matCellDef="let element">{{element.reporteServicio}}</td>
+                </ng-container>
+
                 <ng-container matColumnDef="acciones">
                     <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
                     <td mat-cell *matCellDef="let element">

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.ts
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.ts
@@ -13,7 +13,7 @@ import { TecnicosService } from '../services/tecnicos.service';
 export class TicketsComponent implements OnInit {
 public tickets: any;
   public dataSource: any;
-  public displayedColumns = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre', 'info1', 'info2', 'info3', 'acciones'];
+  public displayedColumns = ['id', 'fecha', 'cantidad', 'type', 'status', 'nombre', 'info1', 'info2', 'info3', 'reporte', 'acciones'];
 
   /*@ViewChild es un decorador que permite acceder a un componente hijo del DOM */
   @ViewChild(MatPaginator) paginator!: MatPaginator;


### PR DESCRIPTION
## Summary
- add `reporteServicio` field to Ticket entity
- allow finalizing a ticket with a report
- expose new endpoint `/tickets/{id}/finalizar`
- create Angular component for entering the service report
- add route and service methods for report saving
- show report column in ticket list

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68680d2ba26883238e3c209217c4cd65