### PR TITLE
Implement change tracking in ticket history

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/TicketHistory.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/TicketHistory.java
@@ -31,6 +31,8 @@ public class TicketHistory {
 
     private String action;
 
+    private String changes;
+
     @Enumerated(EnumType.STRING)
     private TicketStatus previousStatus;
 

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -48,10 +48,11 @@ public class TicketService {
     @Autowired
     private TicketHistoryRepository historyRepository;
 
-    private void saveHistory(Ticket ticket, String action, TicketStatus previous, TicketStatus current) {
+    private void saveHistory(Ticket ticket, String action, TicketStatus previous, TicketStatus current, String changes) {
         historyRepository.save(TicketHistory.builder()
                 .ticket(ticket)
                 .action(action)
+                .changes(changes)
                 .previousStatus(previous)
                 .newStatus(current)
                 .timestamp(java.time.LocalDateTime.now())
@@ -151,7 +152,7 @@ public class TicketService {
                 .build();
 
         Ticket saved = ticketRepository.save(ticket);
-        saveHistory(saved, "CREATED", null, saved.getStatus());
+        saveHistory(saved, "CREATED", null, saved.getStatus(), null);
         return saved;
 
     }
@@ -178,6 +179,7 @@ public class TicketService {
 
         Ticket ticket = ticketRepository.findById(id).orElseThrow();
         TicketStatus previousStatus = ticket.getStatus();
+        StringBuilder changes = new StringBuilder();
 
         Path filePath = null;
         if (file != null && !file.isEmpty()) {
@@ -218,27 +220,86 @@ public class TicketService {
             cliente = clienteRepository.findById(clienteId).orElse(null);
         }
 
-        ticket.setFecha(date);
-        ticket.setCantidad(cantidad);
-        ticket.setServicio(servicio);
-        ticket.setType(typeTicket);
-        ticket.setTecnico(tecnico);
-        ticket.setCliente(cliente);
-        ticket.setInstalacionEquipo(instalacionEquipo);
-        ticket.setInstalacionModelo(instalacionModelo);
-        ticket.setInstalacionDireccion(instalacionDireccion);
-        ticket.setMantenimientoEquipo(mantenimientoEquipo);
-        ticket.setMantenimientoDescripcion(mantenimientoDescripcion);
-        ticket.setMantenimientoProxima(mantenimientoProxima);
-        ticket.setCotizacionCliente(cotizacionCliente);
-        ticket.setCotizacionMonto(cotizacionMonto);
-        ticket.setCotizacionDescripcion(cotizacionDescripcion);
-        ticket.setDiagnosticoEquipo(diagnosticoEquipo);
-        ticket.setDiagnosticoProblema(diagnosticoProblema);
-        ticket.setDiagnosticoObservaciones(diagnosticoObservaciones);
+        if (!ticket.getFecha().equals(date)) {
+            changes.append("fecha: ").append(ticket.getFecha()).append(" -> ").append(date).append("; ");
+            ticket.setFecha(date);
+        }
+        if (ticket.getCantidad() != cantidad) {
+            changes.append("cantidad: ").append(ticket.getCantidad()).append(" -> ").append(cantidad).append("; ");
+            ticket.setCantidad(cantidad);
+        }
+        if (ticket.getServicio() == null || !ticket.getServicio().getNombre().equals(servicioNombre)) {
+            String oldVal = ticket.getServicio() != null ? ticket.getServicio().getNombre() : "null";
+            changes.append("servicio: ").append(oldVal).append(" -> ").append(servicioNombre).append("; ");
+            ticket.setServicio(servicio);
+        }
+        if (ticket.getType() != typeTicket) {
+            changes.append("type: ").append(ticket.getType()).append(" -> ").append(typeTicket).append("; ");
+            ticket.setType(typeTicket);
+        }
+        if (ticket.getTecnico() == null || !ticket.getTecnico().equals(tecnico)) {
+            String oldVal = ticket.getTecnico() != null ? ticket.getTecnico().getCodigo() : "null";
+            String newVal = tecnico != null ? tecnico.getCodigo() : "null";
+            changes.append("tecnico: ").append(oldVal).append(" -> ").append(newVal).append("; ");
+            ticket.setTecnico(tecnico);
+        }
+        if (ticket.getCliente() == null || !ticket.getCliente().equals(cliente)) {
+            String oldVal = ticket.getCliente() != null ? ticket.getCliente().getId() + "" : "null";
+            String newVal = cliente != null ? cliente.getId() + "" : "null";
+            changes.append("cliente: ").append(oldVal).append(" -> ").append(newVal).append("; ");
+            ticket.setCliente(cliente);
+        }
+        if (!equalsStr(ticket.getInstalacionEquipo(), instalacionEquipo)) {
+            changes.append("instalacionEquipo: ").append(ticket.getInstalacionEquipo()).append(" -> ").append(instalacionEquipo).append("; ");
+            ticket.setInstalacionEquipo(instalacionEquipo);
+        }
+        if (!equalsStr(ticket.getInstalacionModelo(), instalacionModelo)) {
+            changes.append("instalacionModelo: ").append(ticket.getInstalacionModelo()).append(" -> ").append(instalacionModelo).append("; ");
+            ticket.setInstalacionModelo(instalacionModelo);
+        }
+        if (!equalsStr(ticket.getInstalacionDireccion(), instalacionDireccion)) {
+            changes.append("instalacionDireccion: ").append(ticket.getInstalacionDireccion()).append(" -> ").append(instalacionDireccion).append("; ");
+            ticket.setInstalacionDireccion(instalacionDireccion);
+        }
+        if (!equalsStr(ticket.getMantenimientoEquipo(), mantenimientoEquipo)) {
+            changes.append("mantenimientoEquipo: ").append(ticket.getMantenimientoEquipo()).append(" -> ").append(mantenimientoEquipo).append("; ");
+            ticket.setMantenimientoEquipo(mantenimientoEquipo);
+        }
+        if (!equalsStr(ticket.getMantenimientoDescripcion(), mantenimientoDescripcion)) {
+            changes.append("mantenimientoDescripcion: ").append(ticket.getMantenimientoDescripcion()).append(" -> ").append(mantenimientoDescripcion).append("; ");
+            ticket.setMantenimientoDescripcion(mantenimientoDescripcion);
+        }
+        if (!equalsStr(ticket.getMantenimientoProxima(), mantenimientoProxima)) {
+            changes.append("mantenimientoProxima: ").append(ticket.getMantenimientoProxima()).append(" -> ").append(mantenimientoProxima).append("; ");
+            ticket.setMantenimientoProxima(mantenimientoProxima);
+        }
+        if (!equalsStr(ticket.getCotizacionCliente(), cotizacionCliente)) {
+            changes.append("cotizacionCliente: ").append(ticket.getCotizacionCliente()).append(" -> ").append(cotizacionCliente).append("; ");
+            ticket.setCotizacionCliente(cotizacionCliente);
+        }
+        if (!equalsStr(ticket.getCotizacionMonto(), cotizacionMonto)) {
+            changes.append("cotizacionMonto: ").append(ticket.getCotizacionMonto()).append(" -> ").append(cotizacionMonto).append("; ");
+            ticket.setCotizacionMonto(cotizacionMonto);
+        }
+        if (!equalsStr(ticket.getCotizacionDescripcion(), cotizacionDescripcion)) {
+            changes.append("cotizacionDescripcion: ").append(ticket.getCotizacionDescripcion()).append(" -> ").append(cotizacionDescripcion).append("; ");
+            ticket.setCotizacionDescripcion(cotizacionDescripcion);
+        }
+        if (!equalsStr(ticket.getDiagnosticoEquipo(), diagnosticoEquipo)) {
+            changes.append("diagnosticoEquipo: ").append(ticket.getDiagnosticoEquipo()).append(" -> ").append(diagnosticoEquipo).append("; ");
+            ticket.setDiagnosticoEquipo(diagnosticoEquipo);
+        }
+        if (!equalsStr(ticket.getDiagnosticoProblema(), diagnosticoProblema)) {
+            changes.append("diagnosticoProblema: ").append(ticket.getDiagnosticoProblema()).append(" -> ").append(diagnosticoProblema).append("; ");
+            ticket.setDiagnosticoProblema(diagnosticoProblema);
+        }
+        if (!equalsStr(ticket.getDiagnosticoObservaciones(), diagnosticoObservaciones)) {
+            changes.append("diagnosticoObservaciones: ").append(ticket.getDiagnosticoObservaciones()).append(" -> ").append(diagnosticoObservaciones).append("; ");
+            ticket.setDiagnosticoObservaciones(diagnosticoObservaciones);
+        }
 
         Ticket saved = ticketRepository.save(ticket);
-        saveHistory(saved, "UPDATED", previousStatus, saved.getStatus());
+        saveHistory(saved, "UPDATED", previousStatus, saved.getStatus(), changes.toString());
         return saved;
     }
     public byte[] getArchivoPorId(Long ticketId) throws IOException{
@@ -261,7 +322,7 @@ public class TicketService {
         TicketStatus previous = ticket.getStatus();
         ticket.setStatus(status);
         Ticket saved = ticketRepository.save(ticket);
-        saveHistory(saved, "STATUS_CHANGED", previous, saved.getStatus());
+        saveHistory(saved, "STATUS_CHANGED", previous, saved.getStatus(), "status cambiado");
         return saved;
     }
 
@@ -270,7 +331,7 @@ public class TicketService {
         if (!ticket.isDeleted()) {
             ticket.setDeleted(true);
             Ticket saved = ticketRepository.save(ticket);
-            saveHistory(saved, "DELETED", saved.getStatus(), saved.getStatus());
+            saveHistory(saved, "DELETED", saved.getStatus(), saved.getStatus(), null);
         }
     }
 
@@ -279,7 +340,7 @@ public class TicketService {
         if (ticket.isDeleted()) {
             ticket.setDeleted(false);
             Ticket saved = ticketRepository.save(ticket);
-            saveHistory(saved, "RESTORED", saved.getStatus(), saved.getStatus());
+            saveHistory(saved, "RESTORED", saved.getStatus(), saved.getStatus(), null);
             return saved;
         }
         return ticket;
@@ -323,5 +384,11 @@ public class TicketService {
         return ticketRepository.topTecnicos().stream()
                 .map(arr -> new TicketStatsDto(arr[0].toString(), ((Number) arr[1]).longValue()))
                 .toList();
+    }
+
+    private boolean equalsStr(String a, String b) {
+        if (a == null && b == null) return true;
+        if (a == null || b == null) return false;
+        return a.equals(b);
     }
 }

--- a/sistema-tickets-frontend/src/app/models/ticket-history.model.ts
+++ b/sistema-tickets-frontend/src/app/models/ticket-history.model.ts
@@ -1,6 +1,7 @@
 export interface TicketHistory {
   id: number;
   action: string;
+  changes: string | null;
   previousStatus: string | null;
   newStatus: string | null;
   timestamp: string;

--- a/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.html
+++ b/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.html
@@ -13,6 +13,10 @@
           <th mat-header-cell *matHeaderCellDef>Acción</th>
           <td mat-cell *matCellDef="let h">{{h.action}}</td>
         </ng-container>
+        <ng-container matColumnDef="changes">
+          <th mat-header-cell *matHeaderCellDef>Cambios</th>
+          <td mat-cell *matCellDef="let h">{{h.changes}}</td>
+        </ng-container>
         <ng-container matColumnDef="previousStatus">
           <th mat-header-cell *matHeaderCellDef>Status Anterior</th>
           <td mat-cell *matCellDef="let h">{{h.previousStatus}}</td>

--- a/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.ts
+++ b/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.ts
@@ -12,7 +12,7 @@ import { TicketHistory } from '../models/ticket-history.model';
 export class TicketDetailsComponent implements OnInit {
   histories: TicketHistory[] = [];
   dataSource = new MatTableDataSource<TicketHistory>();
-  displayedColumns = ['timestamp','action','previousStatus','newStatus'];
+  displayedColumns = ['timestamp','action','changes','previousStatus','newStatus'];
   ticketId!: number;
 
   constructor(private route: ActivatedRoute, private service: TecnicosService){}


### PR DESCRIPTION
## Summary
- store a textual `changes` summary in `TicketHistory`
- collect field changes when updating a ticket
- expose the changes in the ticket history table

## Testing
- `npm test` *(fails: ng not installed)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680e197cf08323ae81882f0742045f