### PR TITLE
Fix stats query and login trimming

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/repository/TicketRepository.java
@@ -25,7 +25,9 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
     @Query(value = "SELECT fecha as label, COUNT(*) as count FROM ticket GROUP BY fecha ORDER BY fecha", nativeQuery = true)
     List<Object[]> countTicketsByDay();
 
-    @Query(value = "SELECT CONCAT(YEAR(fecha), '-W', WEEK(fecha, 1)) as label, COUNT(*) as count FROM ticket GROUP BY YEAR(fecha), WEEK(fecha, 1) ORDER BY YEAR(fecha), WEEK(fecha, 1)", nativeQuery = true)
+    @Query(value = "SELECT DATE_FORMAT(fecha, '%x-W%v') as label, COUNT(*) as count " +
+            "FROM ticket GROUP BY DATE_FORMAT(fecha, '%x-W%v') ORDER BY DATE_FORMAT(fecha, '%x-W%v')",
+            nativeQuery = true)
     List<Object[]> countTicketsByWeek();
 
     @Query(value = "SELECT DATE_FORMAT(fecha, '%Y-%m') as label, COUNT(*) as count FROM ticket GROUP BY DATE_FORMAT(fecha, '%Y-%m') ORDER BY DATE_FORMAT(fecha, '%Y-%m')", nativeQuery = true)

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/AuthController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/AuthController.java
@@ -29,8 +29,10 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<Usuario> login(@RequestBody Usuario loginRequest){
-        Usuario usuario = usuarioRepository.findByUsername(loginRequest.getUsername());
-        if(usuario != null && usuario.getPassword().equals(loginRequest.getPassword())){
+        String username = loginRequest.getUsername() == null ? null : loginRequest.getUsername().trim();
+        String password = loginRequest.getPassword() == null ? null : loginRequest.getPassword().trim();
+        Usuario usuario = usuarioRepository.findByUsername(username);
+        if(usuario != null && usuario.getPassword().equals(password)){
             return ResponseEntity.ok(usuario);
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();


### PR DESCRIPTION
## Summary
- fix weekly stats query using `DATE_FORMAT`
- trim login credentials before comparing in backend

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: ng permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68681d9b25288323902ff5ed4964a860