### PR TITLE
Add endpoints to manage technicians

### DIFF
--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -83,4 +83,12 @@ export class TecnicosService {
     return this.http.get<TicketHistory[]>(`${environment.backendHost}/tickets/${id}/history`);
   }
 
+  public editarTecnico(codigo: string, tecnico: Tecnico): Observable<Tecnico> {
+    return this.http.put<Tecnico>(`${environment.backendHost}/tecnicos/${codigo}`, tecnico);
+  }
+
+  public eliminarTecnico(codigo: string): Observable<void> {
+    return this.http.delete<void>(`${environment.backendHost}/tecnicos/${codigo}`);
+  }
+
 }


### PR DESCRIPTION
## Summary
- allow PUT and DELETE on `/tecnicos/{codigo}` in backend
- expose new editing and deleting methods in frontend service

## Testing
- `./mvnw -q test` *(fails: unable to resolve Maven dependencies)*
- `npm test --silent` *(fails: cannot find optional dependency @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6868203cc86483239c3bcc5366693ee9