### PR TITLE
Add endpoints to manage technicians

### DIFF
--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import { AuthorizationGuard } from './guards/authorization.guard';
 import { TecnicoDetallesComponent } from './tecnico-detalles/tecnico-detalles.component';
 import { NewTicketComponent } from './new-ticket/new-ticket.component';
 import { EditTicketComponent } from './edit-ticket/edit-ticket.component';
+import { EditTecnicoComponent } from './edit-tecnico/edit-tecnico.component';
 
 
 import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
@@ -120,6 +121,12 @@ const routes: Routes = [
       {
         path: "edit-ticket/:id",
         component: EditTicketComponent,
+        canActivate: [AuthorizationGuard],
+        data: { roles: ["ADMIN"] }
+      },
+      {
+        path: "edit-tecnico/:codigo",
+        component: EditTecnicoComponent,
         canActivate: [AuthorizationGuard],
         data: { roles: ["ADMIN"] }
       },

--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -44,6 +44,7 @@ import { QuotesComponent } from './quotes/quotes.component';
 import { GreetingComponent } from './greeting/greeting.component';
 import { TicketReportComponent } from './ticket-report/ticket-report.component';
 import { TicketDetailsComponent } from './ticket-details/ticket-details.component';
+import { EditTecnicoComponent } from './edit-tecnico/edit-tecnico.component';
 
 
 @NgModule({
@@ -69,6 +70,7 @@ import { TicketDetailsComponent } from './ticket-details/ticket-details.componen
     GreetingComponent,
     TicketReportComponent,
     TicketDetailsComponent,
+    EditTecnicoComponent,
 
   ],
   imports: [

--- a/sistema-tickets-frontend/src/app/edit-tecnico/edit-tecnico.component.html
+++ b/sistema-tickets-frontend/src/app/edit-tecnico/edit-tecnico.component.html
@@ -1,0 +1,38 @@
+<div class="container">
+  <mat-card *ngIf="tecnicoForm" [formGroup]="tecnicoForm" class="tecnico-form">
+    <mat-card-header>
+      <mat-card-title>Editar Técnico</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <mat-form-field appearance="outline">
+        <mat-label>Nombre</mat-label>
+        <input matInput formControlName="nombre" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Apellido</mat-label>
+        <input matInput formControlName="apellido" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Usuario</mat-label>
+        <input matInput formControlName="username" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Contraseña</mat-label>
+        <input matInput type="password" formControlName="password" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Código</mat-label>
+        <input matInput formControlName="codigo" readonly />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Servicios</mat-label>
+        <mat-select formControlName="especialidades" multiple>
+          <mat-option *ngFor="let s of servicios" [value]="s">{{ s.nombre }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-card-actions>
+        <button mat-raised-button color="primary" (click)="guardarCambios()">Actualizar Técnico</button>
+      </mat-card-actions>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/sistema-tickets-frontend/src/app/edit-tecnico/edit-tecnico.component.spec.ts
+++ b/sistema-tickets-frontend/src/app/edit-tecnico/edit-tecnico.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EditTecnicoComponent } from './edit-tecnico.component';
+
+describe('EditTecnicoComponent', () => {
+  let component: EditTecnicoComponent;
+  let fixture: ComponentFixture<EditTecnicoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EditTecnicoComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EditTecnicoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/sistema-tickets-frontend/src/app/edit-tecnico/edit-tecnico.component.ts
+++ b/sistema-tickets-frontend/src/app/edit-tecnico/edit-tecnico.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TecnicosService } from '../services/tecnicos.service';
+import { ServiciosService } from '../services/servicios.service';
+import { Servicio } from '../models/servicio.model';
+import Swal from 'sweetalert2';
+
+@Component({
+  selector: 'app-edit-tecnico',
+  templateUrl: './edit-tecnico.component.html',
+})
+export class EditTecnicoComponent implements OnInit {
+  tecnicoForm!: FormGroup;
+  servicios: Servicio[] = [];
+  codigo!: string;
+
+  constructor(
+    private fb: FormBuilder,
+    private tecnicosService: TecnicosService,
+    private serviciosService: ServiciosService,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.tecnicoForm = this.fb.group({
+      nombre: ['', Validators.required],
+      apellido: ['', Validators.required],
+      username: [''],
+      password: [''],
+      codigo: [''],
+      especialidades: [[], Validators.required]
+    });
+
+    this.serviciosService.getServicios().subscribe({
+      next: s => (this.servicios = s),
+      error: err => console.error('Error al obtener servicios', err)
+    });
+
+    this.route.params.subscribe(params => {
+      this.codigo = params['codigo'];
+      this.tecnicosService.getTecnicoPorCodigo(this.codigo).subscribe({
+        next: t => {
+          this.tecnicoForm.patchValue({
+            nombre: t.nombre,
+            apellido: t.apellido,
+            codigo: t.codigo,
+            username: t.username,
+            especialidades: t.especialidades
+          });
+        },
+        error: err => console.error('Error al cargar técnico', err)
+      });
+    });
+  }
+
+  guardarCambios() {
+    if (this.tecnicoForm.invalid) {
+      return;
+    }
+    this.tecnicosService.editarTecnico(this.codigo, this.tecnicoForm.value).subscribe({
+      next: () => {
+        Swal.fire('Técnico actualizado', 'El técnico se actualizó correctamente', 'success');
+        this.router.navigate(['/admin/tecnicos']);
+      },
+      error: () => {
+        Swal.fire('Error', 'No se pudo actualizar el técnico', 'error');
+      }
+    });
+  }
+}

--- a/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
+++ b/sistema-tickets-frontend/src/app/services/tecnicos.service.ts
@@ -83,4 +83,12 @@ export class TecnicosService {
     return this.http.get<TicketHistory[]>(`${environment.backendHost}/tickets/${id}/history`);
   }
 
+  public editarTecnico(codigo: string, tecnico: Tecnico): Observable<Tecnico> {
+    return this.http.put<Tecnico>(`${environment.backendHost}/tecnicos/${codigo}`, tecnico);
+  }
+
+  public eliminarTecnico(codigo: string): Observable<void> {
+    return this.http.delete<void>(`${environment.backendHost}/tecnicos/${codigo}`);
+  }
+
 }

--- a/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.html
@@ -93,6 +93,18 @@
                         </td>
                     </ng-container>
 
+                    <ng-container matColumnDef="acciones">
+                        <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
+                        <td mat-cell *matCellDef="let tecnico">
+                            <button mat-icon-button color="primary" (click)="editarTecnico(tecnico)">
+                                <mat-icon>edit</mat-icon>
+                            </button>
+                            <button mat-icon-button color="warn" (click)="eliminarTecnico(tecnico)">
+                                <mat-icon>delete</mat-icon>
+                            </button>
+                        </td>
+                    </ng-container>
+
                     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
                     <tr mat-row
                         *matRowDef="let row; columns: displayedColumns;"></tr>

--- a/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnicos/tecnicos.component.ts
@@ -6,6 +6,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { Tecnico } from '../models/tecnicos.model';
 import { TecnicosService } from '../services/tecnicos.service';
 import { Router } from '@angular/router';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-tecnicos',
@@ -16,7 +17,7 @@ export class TecnicosComponent implements OnInit {
 
   tecnicos!: Array<Tecnico>;
   tecnicosDataSource!: MatTableDataSource<Tecnico>;
-  displayedColumns: string[] = ['id', 'nombre', 'apellido', 'codigo', 'especialidades','tickets'];
+  displayedColumns: string[] = ['id', 'nombre', 'apellido', 'codigo', 'especialidades','tickets','acciones'];
 
   constructor(private tecnicoService: TecnicosService, private router: Router) { }
 
@@ -34,6 +35,33 @@ export class TecnicosComponent implements OnInit {
 
   listarTicketsDeTecnico(tecnico: Tecnico) {
     this.router.navigateByUrl(`/admin/tecnico-detalles/${tecnico.codigo}`);
+  }
+
+  editarTecnico(tecnico: Tecnico) {
+    this.router.navigate(['/admin/edit-tecnico', tecnico.codigo]);
+  }
+
+  eliminarTecnico(tecnico: Tecnico) {
+    Swal.fire({
+      title: '¿Eliminar técnico?',
+      text: 'Esta acción no se puede deshacer',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Sí, eliminar'
+    }).then(result => {
+      if (result.isConfirmed) {
+        this.tecnicoService.eliminarTecnico(tecnico.codigo).subscribe({
+          next: () => {
+            this.tecnicos = this.tecnicos.filter(t => t.codigo !== tecnico.codigo);
+            this.tecnicosDataSource.data = this.tecnicos;
+            Swal.fire('Eliminado', 'El técnico ha sido eliminado', 'success');
+          },
+          error: () => {
+            Swal.fire('Error', 'No se pudo eliminar el técnico', 'error');
+          }
+        });
+      }
+    });
   }
 
   getServiciosNombres(tecnico: Tecnico): string {


### PR DESCRIPTION
## Summary
- allow PUT and DELETE on `/tecnicos/{codigo}` in backend
- expose new editing and deleting methods in frontend service
- show edit & delete actions in technician table
- add `EditTecnicoComponent` with route `/admin/edit-tecnico/:codigo`

## Testing
- `bash mvnw -q test` *(fails: unable to resolve Maven dependencies)*
- `npm test --silent` *(fails: permission denied running ng)*

------
https://chatgpt.com/codex/tasks/task_e_6868203cc86483239c3bcc5366693ee9