### PR TITLE
Fix checkbox form control error

### DIFF
--- a/sistema-tickets-frontend/src/app/app.module.ts
+++ b/sistema-tickets-frontend/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { EditTicketComponent } from './edit-ticket/edit-ticket.component';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { TecnicoDashboardComponent } from './tecnico-dashboard/tecnico-dashboard.component';
 import { LoadServiciosComponent } from './load-servicios/load-servicios.component';
 import { LoadClientesComponent } from './load-clientes/load-clientes.component';
@@ -79,7 +80,7 @@ import { EditTecnicoComponent } from './edit-tecnico/edit-tecnico.component';
     MatToolbarModule, MatButtonModule, MatIconModule, MatMenuModule, MatSidenavModule, MatListModule,
     MatCardModule, MatFormFieldModule, MatInputModule, ReactiveFormsModule, FormsModule, MatTableModule,
     HttpClientModule, MatPaginatorModule, MatSortModule, MatProgressSpinnerModule,
-    MatDatepickerModule, MatNativeDateModule, MatSelectModule, BrowserModule
+    MatDatepickerModule, MatNativeDateModule, MatSelectModule, MatCheckboxModule, BrowserModule
   ],
   providers: [
     provideClientHydration(),


### PR DESCRIPTION
## Summary
- import `MatCheckboxModule` so Material checkboxes work with reactive forms

## Testing
- `npm test` *(fails: ng Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686bc560a9088323af9675e3bd8bcdd6