### PR TITLE
Fix null tecnico name display

### DIFF
--- a/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.html
+++ b/sistema-tickets-frontend/src/app/tecnico-detalles/tecnico-detalles.component.html
@@ -46,7 +46,7 @@
                     <th mat-header-cell *matHeaderCellDef >
                         TECNICO </th>
                     <td mat-cell
-                        *matCellDef="let element">{{element.tecnico.nombre}}</td>
+                        *matCellDef="let element">{{ element.tecnico?.nombre }}</td>
                 </ng-container>
 
                 <ng-container matColumnDef="info1">


### PR DESCRIPTION
## Summary
- prevent null tecnico from breaking view

## Testing
- `npx ng test --watch=false` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc5993c208323bc53ed7f048950f8