### PR TITLE
Fix optional client id when saving tickets

### DIFF
--- a/sistema-tickets-frontend/src/app/edit-ticket/edit-ticket.component.ts
+++ b/sistema-tickets-frontend/src/app/edit-ticket/edit-ticket.component.ts
@@ -144,7 +144,9 @@ export class EditTicketComponent implements OnInit{
   formData.set('cantidad', this.ticketFormGroup.value.cantidad);
   formData.set('servicio', this.ticketFormGroup.value.servicio);
   formData.set('priority', this.ticketFormGroup.value.priority);
-  formData.set('clienteId', this.ticketFormGroup.value.clienteId);
+  if(this.ticketFormGroup.value.clienteId){
+    formData.set('clienteId', this.ticketFormGroup.value.clienteId);
+  }
   if (this.ticketFormGroup.value.fileSource) {
     formData.append('file', this.ticketFormGroup.value.fileSource);
   }

--- a/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.ts
+++ b/sistema-tickets-frontend/src/app/new-ticket/new-ticket.component.ts
@@ -129,7 +129,9 @@ guardarTicket() {
   formData.set('cantidad', this.ticketFormGroup.value.cantidad);
   formData.set('servicio', this.ticketFormGroup.value.servicio);
   formData.set('priority', this.ticketFormGroup.value.priority);
-  formData.set('clienteId', this.ticketFormGroup.value.clienteId);
+  if(this.ticketFormGroup.value.clienteId){
+    formData.set('clienteId', this.ticketFormGroup.value.clienteId);
+  }
   if (this.ticketFormGroup.value.fileSource) {
     formData.append('file', this.ticketFormGroup.value.fileSource);
   }


### PR DESCRIPTION
## Summary
- handle optional `clienteId` in new-ticket and edit-ticket forms

## Testing
- `npm test` *(fails: `ng` permission denied)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686c67fe55288323a5977136082e273a