### PR TITLE
Fix SQL syntax error when inserting Notification

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Notification.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Notification.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -31,6 +32,7 @@ public class Notification {
     private String message;
 
     @Builder.Default
+    @Column(name = "is_read")
     private boolean read = false;
 
     private LocalDateTime createdAt;


### PR DESCRIPTION
## Summary
- avoid using `read` as a column name

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686c8b05f38c8323a1eff9600072902c