### PR TITLE
Fix unauthorized status update error code

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -28,6 +28,8 @@ import com.compulandia.sistematickets.repository.TicketHistoryRepository;
 import com.compulandia.sistematickets.repository.ClienteRepository;
 import com.compulandia.sistematickets.repository.ServicioRepository;
 import com.compulandia.sistematickets.services.NotificationService;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 
 import jakarta.transaction.Transactional;
@@ -372,7 +374,7 @@ public class TicketService {
     public Ticket actualizaTicketPorStatus(TicketStatus status, long id, String codigoTecnico){
         Ticket ticket = ticketRepository.findById(id).orElseThrow();
         if(ticket.getTecnico() == null || !ticket.getTecnico().getCodigo().equals(codigoTecnico)){
-            throw new RuntimeException("No autorizado");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No autorizado");
         }
         TicketStatus previous = ticket.getStatus();
         ticket.setStatus(status);


### PR DESCRIPTION
## Summary
- return HTTP 403 instead of 500 when a technician updates a ticket they don't own

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686c8ca09fac8323b66337b230ee1f34