### PR TITLE
Fix technician dashboard table

### DIFF
--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
@@ -52,7 +52,7 @@
       </ng-container>
       <ng-container matColumnDef="nombre">
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
-        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+        <td mat-cell *matCellDef="let element">{{ element.tecnico?.nombre || 'Sin asignar' }}</td>
       </ng-container>
       <ng-container matColumnDef="acciones">
         <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
@@ -60,6 +60,7 @@
           <button mat-button color="primary" *ngIf="element.status === 'PENDIENTE'" (click)="marcarEnProceso(element)">Iniciar</button>
           <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
           <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+          <button mat-button (click)="verDetalles(element)">Detalles</button>
         </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
@@ -92,7 +93,7 @@
       </ng-container>
       <ng-container matColumnDef="nombre">
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
-        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+        <td mat-cell *matCellDef="let element">{{ element.tecnico?.nombre || 'Sin asignar' }}</td>
       </ng-container>
       <ng-container matColumnDef="acciones">
         <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
@@ -100,6 +101,7 @@
           <button mat-button color="primary" *ngIf="element.status === 'PENDIENTE'" (click)="marcarEnProceso(element)">Iniciar</button>
           <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
           <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+          <button mat-button (click)="verDetalles(element)">Detalles</button>
         </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
@@ -132,13 +134,14 @@
       </ng-container>
       <ng-container matColumnDef="nombre">
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
-        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+        <td mat-cell *matCellDef="let element">{{ element.tecnico?.nombre || 'Sin asignar' }}</td>
       </ng-container>
       <ng-container matColumnDef="acciones">
         <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
         <td mat-cell *matCellDef="let element">
           <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
           <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+          <button mat-button (click)="verDetalles(element)">Detalles</button>
         </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
@@ -171,7 +174,7 @@
       </ng-container>
       <ng-container matColumnDef="nombre">
         <th mat-header-cell *matHeaderCellDef>TECNICO</th>
-        <td mat-cell *matCellDef="let element">{{element.tecnico.nombre}}</td>
+        <td mat-cell *matCellDef="let element">{{ element.tecnico?.nombre || 'Sin asignar' }}</td>
       </ng-container>
       <ng-container matColumnDef="acciones">
         <th mat-header-cell *matHeaderCellDef>ACCIONES</th>
@@ -179,6 +182,7 @@
           <button mat-button color="primary" *ngIf="element.status === 'PENDIENTE'" (click)="marcarEnProceso(element)">Iniciar</button>
           <button mat-button color="accent" *ngIf="element.status === 'EN_PROCESO'" (click)="finalizarTicket(element)">Finalizar</button>
           <button mat-button color="warn" (click)="cancelarTicket(element)">Cancelar</button>
+          <button mat-button (click)="verDetalles(element)">Detalles</button>
         </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -123,4 +123,8 @@ export class TecnicoDashboardComponent implements OnInit {
   cancelarTicket(ticket: Ticket) {
     this.actualizarEstado(ticket, 'CANCELADO');
   }
+
+  verDetalles(ticket: Ticket){
+    this.router.navigate(['/admin/ticket-details', ticket.id]);
+  }
 }


### PR DESCRIPTION
## Summary
- show technician name when present or 'Sin asignar' otherwise
- add 'Detalles' action in technician dashboard tables
- add navigation method to open ticket details

## Testing
- `node node_modules/@angular/cli/bin/ng test --watch=false` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686c8d391ed483238b1dd1fd32c034ff