### PR TITLE
Add priority color coding

### DIFF
--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.css
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.css
@@ -1,0 +1,21 @@
+/* Color coding for priority levels */
+.priority-label {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.priority-label.baja {
+  background-color: #dff0d8;
+  color: #2e7d32;
+}
+
+.priority-label.media {
+  background-color: #fff4e5;
+  color: #fb8c00;
+}
+
+.priority-label.alta {
+  background-color: #ffebee;
+  color: #c62828;
+}

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.html
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.html
@@ -42,7 +42,11 @@
                 <ng-container matColumnDef="priority">
                     <th mat-header-cell *matHeaderCellDef mat-sort-header>
                         PRIORIDAD </th>
-                    <td mat-cell *matCellDef="let element">{{element.priority}}</td>
+                    <td mat-cell *matCellDef="let element">
+                        <span class="priority-label" [ngClass]="element.priority?.toLowerCase()">
+                            {{ element.priority }}
+                        </span>
+                    </td>
                 </ng-container>
                 <ng-container matColumnDef="nombre">
                     <th mat-header-cell *matHeaderCellDef mat-sort-header>


### PR DESCRIPTION
## Summary
- highlight priority values with color-coded labels

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686c8d533f9c8323a8dca3051d5fa350