### PR TITLE
Add message for non-leader techs

### DIFF
--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.ts
@@ -5,6 +5,7 @@ import { Ticket } from '../models/tecnicos.model';
 import { TecnicosService } from '../services/tecnicos.service';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-tecnico-dashboard',
@@ -108,7 +109,13 @@ export class TecnicoDashboardComponent implements OnInit {
         ticket.status = status;
         this.filterTickets();
       },
-      error: (err) => console.error('Error al actualizar ticket', err)
+      error: (err) => {
+        if (err.status === 403) {
+          Swal.fire('No eres el lider de este servicio', '', 'error');
+        } else {
+          console.error('Error al actualizar ticket', err);
+        }
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- show an alert when a technician who isn't the service leader tries to start a ticket

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c92641a508323a5c91d717456595f