### PR TITLE
Enable read-only ticket details for technicians

### DIFF
--- a/sistema-tickets-frontend/src/app/app-routing.module.ts
+++ b/sistema-tickets-frontend/src/app/app-routing.module.ts
@@ -134,7 +134,7 @@ const routes: Routes = [
         path: "ticket-details/:id",
         component: TicketDetailsComponent,
         canActivate: [AuthorizationGuard],
-        data: { roles: ["ADMIN"] }
+        data: { roles: ["ADMIN", "TECNICO"] }
       },
       {
         path: "cotizaciones",

--- a/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.html
+++ b/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.html
@@ -1,4 +1,33 @@
 <div class="container">
+  <mat-card *ngIf="ticket">
+    <mat-card-header>
+      <mat-card-title>Detalles del Ticket</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <p><strong>ID:</strong> {{ticket.id}}</p>
+      <p><strong>Fecha:</strong> {{ticket.fecha}}</p>
+      <p><strong>Cantidad:</strong> {{ticket.cantidad}}</p>
+      <p><strong>Tipo:</strong> {{ticket.type}}</p>
+      <p><strong>Status:</strong> {{ticket.status}}</p>
+      <p><strong>Prioridad:</strong> {{ticket.priority}}</p>
+      <p><strong>Técnico:</strong> {{ticket.tecnico?.nombre}}</p>
+      <p><strong>Servicio:</strong> {{ticket.servicio?.nombre}}</p>
+      <p *ngIf="ticket.instalacionEquipo"><strong>Equipo:</strong> {{ticket.instalacionEquipo}}</p>
+      <p *ngIf="ticket.instalacionModelo"><strong>Modelo:</strong> {{ticket.instalacionModelo}}</p>
+      <p *ngIf="ticket.instalacionDireccion"><strong>Dirección:</strong> {{ticket.instalacionDireccion}}</p>
+      <p *ngIf="ticket.mantenimientoEquipo"><strong>Equipo:</strong> {{ticket.mantenimientoEquipo}}</p>
+      <p *ngIf="ticket.mantenimientoDescripcion"><strong>Descripción:</strong> {{ticket.mantenimientoDescripcion}}</p>
+      <p *ngIf="ticket.mantenimientoProxima"><strong>Próxima:</strong> {{ticket.mantenimientoProxima}}</p>
+      <p *ngIf="ticket.cotizacionCliente"><strong>Cliente:</strong> {{ticket.cotizacionCliente}}</p>
+      <p *ngIf="ticket.cotizacionMonto"><strong>Monto:</strong> {{ticket.cotizacionMonto}}</p>
+      <p *ngIf="ticket.cotizacionDescripcion"><strong>Descripción:</strong> {{ticket.cotizacionDescripcion}}</p>
+      <p *ngIf="ticket.diagnosticoEquipo"><strong>Equipo:</strong> {{ticket.diagnosticoEquipo}}</p>
+      <p *ngIf="ticket.diagnosticoProblema"><strong>Problema:</strong> {{ticket.diagnosticoProblema}}</p>
+      <p *ngIf="ticket.diagnosticoObservaciones"><strong>Observaciones:</strong> {{ticket.diagnosticoObservaciones}}</p>
+      <p><strong>Pagado:</strong> {{ticket.pagado ? 'Sí' : 'No'}}</p>
+      <p *ngIf="ticket.reporteServicio"><strong>Reporte:</strong> {{ticket.reporteServicio}}</p>
+    </mat-card-content>
+  </mat-card>
   <mat-card>
     <mat-card-header>
       <mat-card-title>Historial de Ticket</mat-card-title>

--- a/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.ts
+++ b/sistema-tickets-frontend/src/app/ticket-details/ticket-details.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { MatTableDataSource } from '@angular/material/table';
 import { TecnicosService } from '../services/tecnicos.service';
 import { TicketHistory } from '../models/ticket-history.model';
+import { Ticket } from '../models/tecnicos.model';
 
 @Component({
   selector: 'app-ticket-details',
@@ -14,12 +15,16 @@ export class TicketDetailsComponent implements OnInit {
   dataSource = new MatTableDataSource<TicketHistory>();
   displayedColumns = ['timestamp','action','changes','previousStatus','newStatus'];
   ticketId!: number;
+  ticket?: Ticket;
 
   constructor(private route: ActivatedRoute, private service: TecnicosService){}
 
   ngOnInit(): void {
     this.route.params.subscribe(params => {
       this.ticketId = +params['id'];
+      this.service.getTicket(this.ticketId).subscribe(t => {
+        this.ticket = t;
+      });
       this.service.getTicketHistory(this.ticketId).subscribe((data: TicketHistory[]) => {
         this.histories = data;
         this.dataSource.data = this.histories;


### PR DESCRIPTION
## Summary
- let technicians access `/admin/ticket-details/:id`
- fetch ticket data in `TicketDetailsComponent`
- display full ticket info read-only before the history table

## Testing
- `npx ng test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686c92c33eec832396f4c1dbf46c489b