### PR TITLE
Add status color coding

### DIFF
--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.css
@@ -109,3 +109,30 @@ h3 {
   background-color: #ffebee;
   color: #c62828;
 }
+
+/* Color coding for ticket status */
+.status-label {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.status-label.pendiente {
+  background-color: #fff4e5;
+  color: #fb8c00;
+}
+
+.status-label.en_proceso {
+  background-color: #e0f7fa;
+  color: #0277bd;
+}
+
+.status-label.finalizado {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+}
+
+.status-label.cancelado {
+  background-color: #ffebee;
+  color: #c62828;
+}

--- a/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/tecnico-dashboard/tecnico-dashboard.component.html
@@ -48,7 +48,11 @@
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef>STATUS</th>
-        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+        <td mat-cell *matCellDef="let element">
+          <span class="status-label" [ngClass]="element.status.toLowerCase()">
+            {{ element.status }}
+          </span>
+        </td>
       </ng-container>
       <ng-container matColumnDef="priority">
         <th mat-header-cell *matHeaderCellDef>PRIORIDAD</th>
@@ -97,7 +101,11 @@
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef>STATUS</th>
-        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+        <td mat-cell *matCellDef="let element">
+          <span class="status-label" [ngClass]="element.status.toLowerCase()">
+            {{ element.status }}
+          </span>
+        </td>
       </ng-container>
       <ng-container matColumnDef="priority">
         <th mat-header-cell *matHeaderCellDef>PRIORIDAD</th>
@@ -146,7 +154,11 @@
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef>STATUS</th>
-        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+        <td mat-cell *matCellDef="let element">
+          <span class="status-label" [ngClass]="element.status.toLowerCase()">
+            {{ element.status }}
+          </span>
+        </td>
       </ng-container>
       <ng-container matColumnDef="priority">
         <th mat-header-cell *matHeaderCellDef>PRIORIDAD</th>
@@ -194,7 +206,11 @@
       </ng-container>
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef>STATUS</th>
-        <td mat-cell *matCellDef="let element">{{element.status}}</td>
+        <td mat-cell *matCellDef="let element">
+          <span class="status-label" [ngClass]="element.status.toLowerCase()">
+            {{ element.status }}
+          </span>
+        </td>
       </ng-container>
       <ng-container matColumnDef="priority">
         <th mat-header-cell *matHeaderCellDef>PRIORIDAD</th>

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.css
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.css
@@ -19,3 +19,30 @@
   background-color: #ffebee;
   color: #c62828;
 }
+
+/* Color coding for ticket status */
+.status-label {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.status-label.pendiente {
+  background-color: #fff4e5;
+  color: #fb8c00;
+}
+
+.status-label.en_proceso {
+  background-color: #e0f7fa;
+  color: #0277bd;
+}
+
+.status-label.finalizado {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+}
+
+.status-label.cancelado {
+  background-color: #ffebee;
+  color: #c62828;
+}

--- a/sistema-tickets-frontend/src/app/tickets/tickets.component.html
+++ b/sistema-tickets-frontend/src/app/tickets/tickets.component.html
@@ -25,8 +25,11 @@
                 <ng-container matColumnDef="status">
                     <th mat-header-cell *matHeaderCellDef mat-sort-header>
                         STATUS </th>
-                    <td mat-cell
-                        *matCellDef="let element">{{element.status}}</td>
+                    <td mat-cell *matCellDef="let element">
+                        <span class="status-label" [ngClass]="element.status.toLowerCase()">
+                            {{ element.status }}
+                        </span>
+                    </td>
                 </ng-container>
                 <ng-container matColumnDef="priority">
                     <th mat-header-cell *matHeaderCellDef mat-sort-header>


### PR DESCRIPTION
## Summary
- add status color labels for admin tickets
- add status color labels for tecnico dashboard

## Testing
- `node node_modules/@angular/cli/bin/ng test --no-watch --browsers=ChromeHeadless` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `./mvnw -q test` *(fails: could not resolve spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686c977e496883238f8f84ca3ed2f96c