### PR TITLE
Add email field for technician registration

### DIFF
--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.html
@@ -13,6 +13,10 @@
         <input matInput formControlName="apellido" />
       </mat-form-field>
       <mat-form-field appearance="outline">
+        <mat-label>Email</mat-label>
+        <input matInput formControlName="email" />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
         <mat-label>Usuario</mat-label>
         <input matInput formControlName="username" />
       </mat-form-field>

--- a/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
+++ b/sistema-tickets-frontend/src/app/load-tecnicos/load-tecnicos.component.ts
@@ -20,6 +20,7 @@ export class LoadTecnicosComponent implements OnInit {
     this.tecnicoForm = this.fb.group({
       nombre: ['', Validators.required],
       apellido: ['', Validators.required],
+      email: ['', [Validators.required, Validators.email]],
       username: ['', Validators.required],
       password: ['', Validators.required],
       codigo: [''],

--- a/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
+++ b/sistema-tickets-frontend/src/app/models/tecnicos.model.ts
@@ -5,6 +5,7 @@ export interface Tecnico {
     codigo: string;
     nombre: string;
     apellido: string;
+    email?: string;
     username?: string;
     password?: string;
     especialidades: Servicio[];


### PR DESCRIPTION
## Summary
- allow registration form to set the technician email
- expose email in the technician model

## Testing
- `sh node_modules/.bin/ng test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c97c3552c832399eafe0b95421e57