### PR TITLE
Improve email notification error logging

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/NotificationService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/NotificationService.java
@@ -37,19 +37,30 @@ public class NotificationService {
             .build();
         repository.save(notification);
 
-        if (mailSender != null && tecnico.getEmail() != null && !tecnico.getEmail().isEmpty()) {
-            SimpleMailMessage msg = new SimpleMailMessage();
-            if (fromEmail != null && !fromEmail.isEmpty()) {
-                msg.setFrom(fromEmail);
-            }
-            msg.setTo(tecnico.getEmail());
-            msg.setSubject("Nuevo ticket asignado");
-            msg.setText("Se te ha asignado el ticket #" + ticket.getId());
-            try {
-                mailSender.send(msg);
-            } catch (Exception e) {
-                log.warn("Failed to send email notification", e);
-            }
+        if (mailSender == null) {
+            log.warn("JavaMailSender bean not configured, cannot send email notification");
+            return;
+        }
+
+        if (tecnico.getEmail() == null || tecnico.getEmail().isEmpty()) {
+            log.warn("Technician '{}' does not have an email configured", tecnico.getCodigo());
+            return;
+        }
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        if (fromEmail != null && !fromEmail.isEmpty()) {
+            msg.setFrom(fromEmail);
+        } else {
+            log.info("No 'from' email configured, using default configuration");
+        }
+        msg.setTo(tecnico.getEmail());
+        msg.setSubject("Nuevo ticket asignado");
+        msg.setText("Se te ha asignado el ticket #" + ticket.getId());
+        try {
+            mailSender.send(msg);
+            log.info("Email notification sent to {}", tecnico.getEmail());
+        } catch (Exception e) {
+            log.warn("Failed to send email notification", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add warning logs when mail sender is missing or technician has no email
- log success or missing `from` address when sending email notification

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686c9d58c55883238cc9a2c0df945029