### PR TITLE
Add admin email notification on service completion

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/services/TicketService.java
@@ -411,7 +411,9 @@ public class TicketService {
         Ticket ticket = ticketRepository.findById(id).orElseThrow();
         ticket.setStatus(TicketStatus.FINALIZADO);
         ticket.setReporteServicio(reporte);
-        return ticketRepository.save(ticket);
+        Ticket saved = ticketRepository.save(ticket);
+        notificationService.notifyTicketFinished(saved);
+        return saved;
     }
 
     public List<TicketStatsDto> getStatsByDay() {

--- a/sistema-tickets-backend/src/main/resources/application.properties
+++ b/sistema-tickets-backend/src/main/resources/application.properties
@@ -29,3 +29,5 @@ spring.mail.username=user@example.com
 spring.mail.password=secret
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+admin.notification.email=admin@example.com


### PR DESCRIPTION
## Summary
- send an email to configured admin address when a ticket is finalized
- wire notification call from `TicketService.finalizarConReporte`
- add `admin.notification.email` property

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686d8b7fa0f483239cb565629569d30d