### PR TITLE
Add rating list to admin dashboard

### DIFF
--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Rating.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/entities/Rating.java
@@ -1,5 +1,7 @@
 package com.compulandia.sistematickets.entities;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +22,8 @@ public class Rating {
 
     @Column(columnDefinition = "TEXT")
     private String comment;
+
+    private LocalDateTime fecha;
 
     @ManyToOne
     private Tecnico tecnico;

--- a/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/RatingController.java
+++ b/sistema-tickets-backend/src/main/java/com/compulandia/sistematickets/web/RatingController.java
@@ -1,8 +1,12 @@
 package com.compulandia.sistematickets.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,9 +37,15 @@ public class RatingController {
         Rating rating = Rating.builder()
                 .stars(stars)
                 .comment(comment)
+                .fecha(LocalDateTime.now())
                 .ticket(ticket)
                 .tecnico(tecnico)
                 .build();
         return ratingRepository.save(rating);
+    }
+
+    @GetMapping("/ratings")
+    public List<Rating> getRatings(){
+        return ratingRepository.findAll();
     }
 }

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.html
@@ -65,4 +65,35 @@
       </mat-card-content>
     </mat-card>
   </div>
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Calificaciones recientes</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <table mat-table [dataSource]="ratingsDataSource" class="mat-elevation-z1">
+        <ng-container matColumnDef="ticket">
+          <th mat-header-cell *matHeaderCellDef>Ticket</th>
+          <td mat-cell *matCellDef="let r">{{r.ticket?.id}}</td>
+        </ng-container>
+        <ng-container matColumnDef="tecnico">
+          <th mat-header-cell *matHeaderCellDef>Técnico</th>
+          <td mat-cell *matCellDef="let r">{{r.tecnico?.nombre}}</td>
+        </ng-container>
+        <ng-container matColumnDef="fecha">
+          <th mat-header-cell *matHeaderCellDef>Fecha</th>
+          <td mat-cell *matCellDef="let r">{{r.fecha}}</td>
+        </ng-container>
+        <ng-container matColumnDef="stars">
+          <th mat-header-cell *matHeaderCellDef>Puntuación</th>
+          <td mat-cell *matCellDef="let r">{{r.stars}}</td>
+        </ng-container>
+        <ng-container matColumnDef="comment">
+          <th mat-header-cell *matHeaderCellDef>Comentario</th>
+          <td mat-cell *matCellDef="let r">{{r.comment}}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="ratingColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: ratingColumns"></tr>
+      </table>
+    </mat-card-content>
+  </mat-card>
 </div>

--- a/sistema-tickets-frontend/src/app/dashboard/dashboard.component.ts
+++ b/sistema-tickets-frontend/src/app/dashboard/dashboard.component.ts
@@ -3,6 +3,8 @@ import { Chart } from 'chart.js/auto';
 import { DashboardService } from '../services/dashboard.service';
 import { TicketStat } from '../models/ticket-stat.model';
 import { AdminStats } from '../models/admin-stats.model';
+import { Rating } from '../models/rating.model';
+import { MatTableDataSource } from '@angular/material/table';
 
 @Component({
   selector: 'app-dashboard',
@@ -17,6 +19,8 @@ export class DashboardComponent implements OnInit {
   clientesChart?: Chart;
   tecnicosChart?: Chart;
   adminStats?: AdminStats;
+  ratingsDataSource = new MatTableDataSource<Rating>();
+  ratingColumns: string[] = ['ticket','tecnico','fecha','stars','comment'];
 
   constructor(private dashboardService: DashboardService) {}
 
@@ -28,6 +32,7 @@ export class DashboardComponent implements OnInit {
     this.dashboardService.getTopServicios().subscribe(d => this.createChart('serviciosChart', d));
     this.dashboardService.getTopClientes().subscribe(d => this.createChart('clientesChart', d));
     this.dashboardService.getTopTecnicos().subscribe(d => this.createChart('tecnicosChart', d));
+    this.dashboardService.getRatings().subscribe(r => this.ratingsDataSource.data = r);
   }
 
   private createChart(elementId: string, stats: TicketStat[]) {

--- a/sistema-tickets-frontend/src/app/models/rating.model.ts
+++ b/sistema-tickets-frontend/src/app/models/rating.model.ts
@@ -1,0 +1,10 @@
+import { Tecnico, Ticket } from './tecnicos.model';
+
+export interface Rating {
+  id: number;
+  stars: number;
+  comment: string;
+  fecha: string;
+  tecnico: Tecnico;
+  ticket: Ticket;
+}

--- a/sistema-tickets-frontend/src/app/services/dashboard.service.ts
+++ b/sistema-tickets-frontend/src/app/services/dashboard.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment.development';
 import { TicketStat } from '../models/ticket-stat.model';
 import { AdminStats } from '../models/admin-stats.model';
+import { Rating } from '../models/rating.model';
 
 @Injectable({
   providedIn: 'root'
@@ -37,5 +38,9 @@ export class DashboardService {
 
   getAdminStats(): Observable<AdminStats> {
     return this.http.get<AdminStats>(`${environment.backendHost}/ticketStats/admin`);
+  }
+
+  getRatings(): Observable<Rating[]> {
+    return this.http.get<Rating[]>(`${environment.backendHost}/ratings`);
   }
 }


### PR DESCRIPTION
## Summary
- add `fecha` field to `Rating` entity
- allow listing ratings via `/ratings` endpoint
- display recent ratings on the admin dashboard

## Testing
- `npm test` *(fails: `ng` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe7a2434083239abd52088d4c5e19